### PR TITLE
Fix docker image tag casing for ghcr.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -25,5 +28,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}


### PR DESCRIPTION
## Summary

Fixes the broken CI build introduced in #11.

`GITHUB_REPOSITORY` preserves original casing (`DigitumDei/Actuarius`), but ghcr.io requires all-lowercase image tags. Added a step to lowercase the value via bash parameter expansion (`${GITHUB_REPOSITORY,,}`) before using it as the image tag.

## Test plan

- [ ] CI build passes on merge to `main`
- [ ] Image appears at `ghcr.io/digitumdei/actuarius:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)