### PR TITLE
Fix startup script CRLF line endings

### DIFF
--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -39,10 +39,13 @@ resource "google_compute_instance" "actuarius" {
     env-claude-creds-b64    = var.claude_credentials_b64
   }
 
-  metadata_startup_script = templatefile("${path.module}/startup.sh", {
-    docker_image    = var.docker_image
-    ask_concurrency = var.ask_concurrency
-  })
+  metadata_startup_script = replace(
+    templatefile("${path.module}/startup.sh", {
+      docker_image    = var.docker_image
+      ask_concurrency = var.ask_concurrency
+    }),
+    "\r\n", "\n"
+  )
 
   service_account {
     email  = google_service_account.actuarius_bot.email


### PR DESCRIPTION
## Summary

Fixes `exit status 126` on VM startup — `startup.sh` was authored on Windows with `\r\n` line endings, causing the shebang to become `/bin/bash^M` which the kernel cannot resolve.

Strips `\r\n` → `\n` via Terraform's `replace()` around the `templatefile()` call, so the script always arrives at GCP with Unix line endings regardless of the host OS.

## Test plan

- [ ] `terraform apply` re-provisions the VM with the corrected script
- [ ] `sudo journalctl -u google-startup-scripts` shows no errors
- [ ] `docker ps` shows `actuarius` container running

🤖 Generated with [Claude Code](https://claude.com/claude-code)