### PR TITLE
Switch Claude auth to long-lived OAuth token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,5 @@ ASK_EXECUTION_TIMEOUT_MS=1200000
 # Git identity for commits made by Claude inside worktrees:
 # GIT_USER_NAME=Actuarius Bot
 # GIT_USER_EMAIL=actuarius-bot@users.noreply.github.com
-# Optional Claude auth bootstrap for container startup:
-# CLAUDE_CREDENTIALS_FILE=/run/secrets/claude_credentials
-# CLAUDE_CREDENTIALS_B64=base64_of_.credentials.json
+# Long-lived Claude OAuth token (generate with: claude setup-token)
+# CLAUDE_CODE_OAUTH_TOKEN=replace_me

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,21 +1,6 @@
 #!/bin/sh
 set -eu
 
-CLAUDE_HOME="${HOME:-/home/appuser}/.claude"
-CLAUDE_CREDENTIALS_TARGET="$CLAUDE_HOME/.credentials.json"
-
-mkdir -p "$CLAUDE_HOME"
-
-if [ -n "${CLAUDE_CREDENTIALS_FILE:-}" ] && [ -f "${CLAUDE_CREDENTIALS_FILE}" ]; then
-  cp "${CLAUDE_CREDENTIALS_FILE}" "$CLAUDE_CREDENTIALS_TARGET"
-  chmod 600 "$CLAUDE_CREDENTIALS_TARGET"
-elif [ -n "${CLAUDE_CREDENTIALS_B64:-}" ]; then
-  tmp_file="$CLAUDE_HOME/.credentials.json.tmp"
-  printf "%s" "$CLAUDE_CREDENTIALS_B64" | base64 -d > "$tmp_file"
-  mv "$tmp_file" "$CLAUDE_CREDENTIALS_TARGET"
-  chmod 600 "$CLAUDE_CREDENTIALS_TARGET"
-fi
-
 GIT_USER_NAME="${GIT_USER_NAME:-Actuarius Bot}"
 GIT_USER_EMAIL="${GIT_USER_EMAIL:-actuarius-bot@users.noreply.github.com}"
 git config --global user.name "$GIT_USER_NAME"

--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -36,7 +36,7 @@ resource "google_compute_instance" "actuarius" {
     env-discord-client-id   = var.discord_client_id
     env-discord-guild-id    = var.discord_guild_id
     env-gh-token            = var.gh_token
-    env-claude-creds-b64    = var.claude_credentials_b64
+    env-claude-oauth-token  = var.claude_oauth_token
   }
 
   metadata_startup_script = replace(

--- a/infra/startup.sh
+++ b/infra/startup.sh
@@ -36,7 +36,7 @@ DISCORD_TOKEN=$(curl -sf -H "$HDR" "$META/env-discord-token")
 DISCORD_CLIENT_ID=$(curl -sf -H "$HDR" "$META/env-discord-client-id")
 DISCORD_GUILD_ID=$(curl -sf -H "$HDR" "$META/env-discord-guild-id" || true)
 GH_TOKEN=$(curl -sf -H "$HDR" "$META/env-gh-token")
-CLAUDE_CREDS_B64=$(curl -sf -H "$HDR" "$META/env-claude-creds-b64")
+CLAUDE_OAUTH_TOKEN=$(curl -sf -H "$HDR" "$META/env-claude-oauth-token")
 
 # --- Pull latest image (public ghcr.io, no auth needed) ---
 docker pull ${docker_image}
@@ -59,7 +59,7 @@ docker run -d \
   -e DISCORD_CLIENT_ID="$DISCORD_CLIENT_ID" \
   $GUILD_ARG \
   -e GH_TOKEN="$GH_TOKEN" \
-  -e CLAUDE_CREDENTIALS_B64="$CLAUDE_CREDS_B64" \
+  -e CLAUDE_CODE_OAUTH_TOKEN="$CLAUDE_OAUTH_TOKEN" \
   -e DATABASE_PATH=/data/app.db \
   -e REPOS_ROOT_PATH=/data/repos \
   -e ASK_CONCURRENCY_PER_GUILD=${ask_concurrency} \

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -16,6 +16,6 @@ discord_client_id = "replace_me"
 # GitHub personal access token (repo scope)
 gh_token = "replace_me"
 
-# Base64-encoded Claude credentials
-# Generate with: base64 -w 0 ~/.claude/.credentials.json
-claude_credentials_b64 = "replace_me"
+# Long-lived Claude OAuth token
+# Generate with: claude setup-token
+claude_oauth_token = "replace_me"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -49,8 +49,8 @@ variable "gh_token" {
   sensitive = true
 }
 
-variable "claude_credentials_b64" {
+variable "claude_oauth_token" {
   type        = string
   sensitive   = true
-  description = "Base64-encoded contents of ~/.claude/.credentials.json"
+  description = "Long-lived Claude OAuth token — generate with: claude setup-token"
 }


### PR DESCRIPTION
## Summary

- Replaces `CLAUDE_CREDENTIALS_B64` (base64 credentials file) with `CLAUDE_CODE_OAUTH_TOKEN`, the officially supported env var for headless Claude CLI auth
- Removes the credentials-file bootstrap block from `docker/entrypoint.sh` entirely — the CLI reads the token directly from the environment
- Updates Terraform variable (`claude_credentials_b64` → `claude_oauth_token`), instance metadata key, and startup script accordingly

## Migration

In `infra/terraform.tfvars`, rename `claude_credentials_b64` → `claude_oauth_token` and set the value from:

```sh
claude setup-token
```

The token is valid for 1 year. No more base64-encoding credentials files.

## Test plan

- [ ] Run `claude setup-token` locally and copy the printed token
- [ ] Set `claude_oauth_token` in `terraform.tfvars`
- [ ] `terraform apply` and confirm the VM restarts cleanly
- [ ] Verify the bot authenticates and `/ask` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)