### PR TITLE
Fix: write redeploy.sh to /var not /usr/local/bin on COS

### DIFF
--- a/infra/startup.sh
+++ b/infra/startup.sh
@@ -45,8 +45,8 @@ DOCKER_IMAGE=$(get_meta "env-docker-image")
 ASK_CONCURRENCY=$(get_meta "env-ask-concurrency")
 
 # --- Install redeploy helper script ---
-get_meta "env-redeploy-script" > /usr/local/bin/redeploy.sh
-chmod +x /usr/local/bin/redeploy.sh
+get_meta "env-redeploy-script" > /var/redeploy.sh
+chmod +x /var/redeploy.sh
 
 # --- Pull latest image (public ghcr.io, no auth needed) ---
 docker pull "$DOCKER_IMAGE"


### PR DESCRIPTION
/usr/local/bin is read-only on Container-Optimized OS. The startup script was failing at that line and exiting before the bot started.

Writes to /var/redeploy.sh instead, which is writable on COS.

Run with: `sudo /var/redeploy.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)