### PR TITLE
feat: move Docker data-root to persistent data disk

### DIFF
--- a/infra/startup.sh
+++ b/infra/startup.sh
@@ -19,8 +19,10 @@ fi
 
 mkdir -p "$DATA_MNT/repos"
 
-# --- Ensure data dir is owned by appuser (UID 1001) inside the container ---
-chown -R 1001:1001 "$DATA_MNT"
+# --- Ensure app dirs are owned by appuser (UID 1001) inside the container ---
+# (Docker's data-root must stay root-owned, so we only chown app directories)
+chown -R 1001:1001 "$DATA_MNT/repos"
+[ -f "$DATA_MNT/app.db" ] && chown 1001:1001 "$DATA_MNT/app.db"
 
 # --- Swap file on data disk (safety margin for Claude CLI subprocesses) ---
 SWAP="$DATA_MNT/.swapfile"
@@ -50,6 +52,14 @@ GOOGLE_GENAI_USE_GCA=$(get_meta "env-google-genai-use-gca")
 # --- Install redeploy helper script ---
 get_meta "env-redeploy-script" > /var/redeploy.sh
 chmod +x /var/redeploy.sh
+
+# --- Move Docker data-root to the persistent data disk ---
+DOCKER_DATA="$DATA_MNT/docker"
+mkdir -p "$DOCKER_DATA"
+cat > /etc/docker/daemon.json <<DJSON
+{"data-root": "$DOCKER_DATA"}
+DJSON
+systemctl restart docker
 
 # --- Pull latest image (public ghcr.io, no auth needed) ---
 docker pull "$DOCKER_IMAGE"


### PR DESCRIPTION
## Summary
- Configures Docker `daemon.json` to use `/mnt/disks/data/docker` as the data-root, so image layers and container state live on the persistent data disk instead of the boot/stateful partition
- Scopes `chown` to app-specific dirs (`repos/`, `app.db`) since Docker's data-root requires root ownership

## Test plan
- [ ] `terraform apply` to push updated startup script
- [ ] Reboot VM or redeploy, verify bot starts normally
- [ ] SSH in and confirm `docker info | grep "Docker Root Dir"` shows `/mnt/disks/data/docker`
- [ ] Confirm `df -h` shows Docker storage on `/dev/sdb` (data disk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)