### PR TITLE
Fix summarizer producing meta-commentary as executive summary

### DIFF
--- a/src/services/adversarialReviewService.ts
+++ b/src/services/adversarialReviewService.ts
@@ -505,7 +505,7 @@ function buildSummarizerPrompt(input: {
     "Synthesize the analyzer and reviewer outputs into a final verdict.",
     "Return JSON only with this exact shape:",
     "{",
-    '  "executiveSummary": "string",',
+    '  "executiveSummary": "2-4 sentences describing what the branch does, summarising the key consensus findings, and explaining why the verdict was reached. Must be substantive analysis — do NOT write meta-commentary such as \'I have reviewed the outputs\' or \'I now have sufficient context\'.",',
     '  "blockingIssues": [{"title":"string","rationale":"string","file":"optional path"}],',
     '  "nonBlockingIssues": [{"title":"string","rationale":"string","file":"optional path"}],',
     '  "missingTests": ["string"],',


### PR DESCRIPTION
## Summary

- The `executiveSummary` field in `buildSummarizerPrompt` was described only as `"string"`, giving the model no guidance on what to write there
- Agentic providers filled it with transitional narration (e.g. "Now I have sufficient context to synthesize the final verdict.") instead of an actual synthesis, and left all issue arrays empty
- Adds an inline description to the schema requiring 2-4 sentences of substantive analysis and explicitly prohibiting meta-commentary

## Test plan

- [ ] Run `/review` on a branch with known issues and confirm the Discord message and markdown artifact contain a real synthesis in the Executive Summary
- [ ] Confirm blocking/non-blocking issue lists are populated when reviewer consensus exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)