### PR TITLE
Fix /install command option ordering (Discord 50035 crash)

### DIFF
--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -68,6 +68,16 @@ export const commandBuilders = [
     .setName("install")
     .setDescription("Install an allowlisted tool or apt package. Requires Manage Server permission.")
     .addStringOption((option) =>
+      option
+        .setName("scope")
+        .setDescription("Installation scope")
+        .setRequired(true)
+        .addChoices(
+          { name: "Repo", value: "repo" },
+          { name: "Request", value: "request" }
+        )
+    )
+    .addStringOption((option) =>
       INSTALLER_PACKAGE_CHOICES.reduce(
         (builder, choice) => builder.addChoices({ name: choice.name, value: choice.value }),
         option.setName("package").setDescription("Allowlisted package ID to install.").setRequired(false)
@@ -78,16 +88,6 @@ export const commandBuilders = [
         .setName("apt-package")
         .setDescription("APT package name or space-separated package specs to install.")
         .setRequired(false)
-    )
-    .addStringOption((option) =>
-      option
-        .setName("scope")
-        .setDescription("Installation scope")
-        .setRequired(true)
-        .addChoices(
-          { name: "Repo", value: "repo" },
-          { name: "Request", value: "request" }
-        )
     ),
   new SlashCommandBuilder()
     .setName("bug")


### PR DESCRIPTION
## Summary
- Discord enforces that required options must be declared before optional ones in slash command definitions
- The `/install` command had `scope` (required) after `package` and `apt-package` (both optional), causing a `50035 Invalid Form Body` error on every startup during command registration
- Reordered the three options: `scope` → `package` → `apt-package`; handler code in `bot.ts` accesses all options by name so no other changes needed

## Test plan
- [ ] `npm run check` passes (no type errors)
- [ ] `docker-compose up --build` — bot starts without a registration error in logs
- [ ] `/install` in Discord shows `scope` as the first (required) option

🤖 Generated with [Claude Code](https://claude.com/claude-code)