### PR TITLE
Fix apt package validation regex (PCRE → ERE)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ if [ "$#" -eq 0 ]; then
 fi
 
 for spec in "$@"; do
-  if ! [[ "$spec" =~ ^[A-Za-z0-9][A-Za-z0-9+.-]*(?::[A-Za-z0-9-]+)?(=[A-Za-z0-9.+:~_-]+)?$ ]]; then
+  if ! [[ "$spec" =~ ^[A-Za-z0-9][A-Za-z0-9+.-]*(:[A-Za-z0-9-]+)?(=[A-Za-z0-9.+:~_-]+)?$ ]]; then
     echo "invalid apt package spec: $spec" >&2
     exit 64
   fi


### PR DESCRIPTION
## Summary
- `actuarius-apt-install` rejected every apt package (e.g. `cmake`) with `invalid apt package spec`
- Root cause: the validation regex used `(?:...)` (PCRE non-capturing group syntax), but bash `[[ =~ ]]` uses POSIX ERE — `(?:...)` is invalid in ERE, so the regex never matched anything
- Fix: replace `(?:...)` with `(...)` in `Dockerfile:67`; capturing groups are valid ERE and identical for pure validation

## Test plan
- [ ] `docker-compose up --build` — image builds successfully
- [ ] `/install apt-package:cmake scope:repo` — installs without error
- [ ] `/install apt-package:invalid!!spec scope:repo` — correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)