### PR TITLE
Add uv, pip (venv), and maturin to installer allowlist

### DIFF
--- a/src/services/installerRegistry.ts
+++ b/src/services/installerRegistry.ts
@@ -471,6 +471,36 @@ export function buildRustupInitDownloadUrl(arch: NodeJS.Architecture = process.a
   return `https://static.rust-lang.org/rustup/dist/${rustupArch}-unknown-linux-gnu/rustup-init`;
 }
 
+export function buildUvDownloadUrl(version: string, arch: NodeJS.Architecture = process.arch): string {
+  const uvArch = (() => {
+    switch (arch) {
+      case "x64":
+        return "x86_64";
+      case "arm64":
+        return "aarch64";
+      default:
+        throw new Error(`Unsupported uv host architecture: ${arch}`);
+    }
+  })();
+
+  return `https://github.com/astral-sh/uv/releases/download/${version}/uv-${uvArch}-unknown-linux-gnu.tar.gz`;
+}
+
+export function buildMaturinDownloadUrl(version: string, arch: NodeJS.Architecture = process.arch): string {
+  const maturinArch = (() => {
+    switch (arch) {
+      case "x64":
+        return "x86_64";
+      case "arm64":
+        return "aarch64";
+      default:
+        throw new Error(`Unsupported maturin host architecture: ${arch}`);
+    }
+  })();
+
+  return `https://github.com/PyO3/maturin/releases/download/v${version}/maturin-${maturinArch}-unknown-linux-musl.tar.gz`;
+}
+
 const packageDefinitions: InstallerPackageDefinition[] = [
   {
     packageId: "rustup-default-stable",
@@ -697,7 +727,7 @@ exec ${shellQuote(rustupBinary)} run ${shellQuote(packageVersion)} rustfmt "$@"
         steps: [
           makeDownloadAndExtractStep(
             "Install uv",
-            `https://github.com/astral-sh/uv/releases/download/${packageVersion}/uv-x86_64-unknown-linux-gnu.tar.gz`,
+            buildUvDownloadUrl(packageVersion),
             archivePath,
             uvDist
           )
@@ -776,7 +806,7 @@ exec ${shellQuote(rustupBinary)} run ${shellQuote(packageVersion)} rustfmt "$@"
         steps: [
           makeDownloadAndExtractStep(
             "Install maturin",
-            `https://github.com/PyO3/maturin/releases/download/v${packageVersion}/maturin-x86_64-unknown-linux-musl.tar.gz`,
+            buildMaturinDownloadUrl(packageVersion),
             archivePath,
             maturinDist
           )

--- a/src/services/installerRegistry.ts
+++ b/src/services/installerRegistry.ts
@@ -681,6 +681,117 @@ exec ${shellQuote(rustupBinary)} run ${shellQuote(packageVersion)} rustfmt "$@"
     }
   },
   {
+    packageId: "uv",
+    defaultVersion: "0.4.18",
+    summary: "uv Python package manager and project tool (uv, uvx).",
+    supportedScopes: ["repo", "request"],
+    buildPlan: (installRoot, packageVersion) => {
+      const uvDist = join(installRoot, "dist");
+      const archivePath = join(installRoot, "downloads", "uv.tar.gz");
+
+      return {
+        packageId: "uv",
+        packageVersion,
+        installRoot,
+        envVars: {},
+        steps: [
+          makeDownloadAndExtractStep(
+            "Install uv",
+            `https://github.com/astral-sh/uv/releases/download/${packageVersion}/uv-x86_64-unknown-linux-gnu.tar.gz`,
+            archivePath,
+            uvDist
+          )
+        ],
+        wrappers: [
+          {
+            binaryName: "uv",
+            scriptBody: makeExecWrapper(join(uvDist, "uv")),
+            verifyArgs: ["--version"]
+          },
+          {
+            binaryName: "uvx",
+            scriptBody: makeExecWrapper(join(uvDist, "uvx")),
+            verifyArgs: ["--version"]
+          }
+        ]
+      };
+    }
+  },
+  {
+    packageId: "pip",
+    defaultVersion: "system",
+    summary: "Python virtual environment with scoped pip, python, and python3.",
+    supportedScopes: ["repo", "request"],
+    buildPlan: (installRoot, packageVersion) => {
+      const venvPath = join(installRoot, "venv");
+
+      return {
+        packageId: "pip",
+        packageVersion,
+        installRoot,
+        envVars: {
+          VIRTUAL_ENV: venvPath
+        },
+        steps: [
+          {
+            label: "Create Python virtual environment",
+            command: "python3",
+            args: ["-m", "venv", venvPath]
+          }
+        ],
+        wrappers: [
+          {
+            binaryName: "pip",
+            scriptBody: makeExecWrapper(join(venvPath, "bin", "pip")),
+            verifyArgs: ["--version"]
+          },
+          {
+            binaryName: "python3",
+            scriptBody: makeExecWrapper(join(venvPath, "bin", "python3")),
+            verifyArgs: ["--version"]
+          },
+          {
+            binaryName: "python",
+            scriptBody: makeExecWrapper(join(venvPath, "bin", "python")),
+            verifyArgs: ["--version"]
+          }
+        ]
+      };
+    }
+  },
+  {
+    packageId: "maturin",
+    defaultVersion: "1.7.1",
+    summary: "Maturin build tool for Rust-based Python packages (PyO3/pyo3).",
+    supportedScopes: ["repo", "request"],
+    buildPlan: (installRoot, packageVersion) => {
+      const maturinDist = join(installRoot, "dist");
+      const archivePath = join(installRoot, "downloads", "maturin.tar.gz");
+
+      return {
+        packageId: "maturin",
+        packageVersion,
+        installRoot,
+        envVars: {},
+        steps: [
+          makeDownloadAndExtractStep(
+            "Install maturin",
+            `https://github.com/PyO3/maturin/releases/download/v${packageVersion}/maturin-x86_64-unknown-linux-musl.tar.gz`,
+            archivePath,
+            maturinDist
+          )
+        ],
+        wrappers: [
+          {
+            binaryName: "maturin",
+            scriptBody: makeExecWrapper(join(maturinDist, "maturin")),
+            verifyArgs: ["--version"]
+          }
+        ]
+      };
+    }
+  },
+  {
     packageId: "android-sdk",
     summary:
       "Android SDK command-line tools, platform-tools, and target platform resolved from repo config. Requires Java (java-temurin) at the same scope.",


### PR DESCRIPTION
## Summary
- Adds three new `/install package:` choices for Python tooling:
  - **`uv`** — downloads prebuilt x86_64 binary from astral-sh/uv releases (default v0.4.18); exposes `uv` and `uvx` wrappers
  - **`pip`** — creates a scoped Python venv at install time; exposes `pip`, `python3`, and `python` wrappers + sets `VIRTUAL_ENV` so tools behave correctly without manual activation
  - **`maturin`** — downloads prebuilt musl binary from PyO3/maturin releases (default v1.7.1); exposes `maturin` wrapper
- `pip` scopes package installs to the worktree — `pip install maturin pytest` etc. work and packages are importable via the scoped `python3`

## Test plan
- [ ] `/install package:pip scope:repo` — venv created, `pip --version` and `python3 --version` work in requests
- [ ] `/install package:uv scope:repo` — `uv --version` works
- [ ] `/install package:maturin scope:repo` — `maturin --version` works
- [ ] After pip install: `pip install pytest` in a worktree finds `pytest` importable

🤖 Generated with [Claude Code](https://claude.com/claude-code)