### PR TITLE
Fix stderr buffer overflow killing Codex/Claude execution

### DIFF
--- a/src/utils/spawnCollect.ts
+++ b/src/utils/spawnCollect.ts
@@ -5,14 +5,22 @@ export interface SpawnResult {
   stderr: string;
 }
 
+const DEFAULT_STDERR_MAX = 64 * 1024; // 64 KB
+
 /**
  * Spawns a child process, collects stdout/stderr, and resolves/rejects on close.
  * stdin is set to "ignore" to prevent CLIs from blocking on interactive input.
+ *
+ * stdout is hard-limited to maxBuffer bytes — EMSGSIZE is thrown if exceeded.
+ * stderr is soft-limited to maxStderrBuffer bytes (default 64 KB) — when exceeded,
+ * the head is discarded and only the tail (most recent bytes) is kept. The process
+ * is never killed due to stderr volume alone. When stderr was truncated, the
+ * returned string is prefixed with "[stderr truncated]\n".
  */
 export function spawnCollect(
   file: string,
   args: string[],
-  options: { cwd: string; timeoutMs: number; maxBuffer: number; env?: NodeJS.ProcessEnv }
+  options: { cwd: string; timeoutMs: number; maxBuffer: number; maxStderrBuffer?: number; env?: NodeJS.ProcessEnv }
 ): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(file, args, { cwd: options.cwd, env: options.env, stdio: ["ignore", "pipe", "pipe"] });
@@ -21,6 +29,9 @@ export function spawnCollect(
     let stderr = "";
     let timedOut = false;
     let bufferOverflow = false;
+    let stderrTruncated = false;
+
+    const effectiveStderrMax = options.maxStderrBuffer ?? DEFAULT_STDERR_MAX;
 
     const timer = setTimeout(() => {
       timedOut = true;
@@ -29,16 +40,19 @@ export function spawnCollect(
 
     child.stdout!.on("data", (chunk: Buffer) => {
       stdout += chunk.toString();
-      if (stdout.length + stderr.length > options.maxBuffer) {
+      if (stdout.length > options.maxBuffer) {
         bufferOverflow = true;
         child.kill("SIGTERM");
       }
     });
+
     child.stderr!.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-      if (stdout.length + stderr.length > options.maxBuffer) {
-        bufferOverflow = true;
-        child.kill("SIGTERM");
+      const combined = stderr + chunk.toString();
+      if (combined.length > effectiveStderrMax) {
+        stderrTruncated = true;
+        stderr = combined.slice(combined.length - effectiveStderrMax);
+      } else {
+        stderr = combined;
       }
     });
 
@@ -49,25 +63,27 @@ export function spawnCollect(
 
     child.on("close", (code, signal) => {
       clearTimeout(timer);
+      const finalStderr = stderrTruncated ? `[stderr truncated]\n${stderr}` : stderr;
+
       if (bufferOverflow) {
         reject(Object.assign(new Error(`Process output exceeded maxBuffer (${options.maxBuffer} bytes)`), {
-          code: "EMSGSIZE", killed: true, signal, stdout, stderr,
+          code: "EMSGSIZE", killed: true, signal, stdout, stderr: finalStderr,
         }));
         return;
       }
       if (timedOut) {
         reject(Object.assign(new Error(`Process timed out after ${options.timeoutMs}ms`), {
-          code: "ETIMEDOUT", killed: true, signal, stdout, stderr,
+          code: "ETIMEDOUT", killed: true, signal, stdout, stderr: finalStderr,
         }));
         return;
       }
       if (code !== 0) {
         reject(Object.assign(new Error(`Process exited with code ${String(code)}`), {
-          killed: false, signal, stdout, stderr,
+          killed: false, signal, stdout, stderr: finalStderr,
         }));
         return;
       }
-      resolve({ stdout, stderr });
+      resolve({ stdout, stderr: finalStderr });
     });
   });
 }

--- a/src/utils/spawnCollect.ts
+++ b/src/utils/spawnCollect.ts
@@ -39,6 +39,7 @@ export function spawnCollect(
     }, options.timeoutMs);
 
     child.stdout!.on("data", (chunk: Buffer) => {
+      if (bufferOverflow || timedOut) return;
       stdout += chunk.toString();
       if (stdout.length > options.maxBuffer) {
         bufferOverflow = true;
@@ -47,6 +48,7 @@ export function spawnCollect(
     });
 
     child.stderr!.on("data", (chunk: Buffer) => {
+      if (bufferOverflow || timedOut) return;
       const combined = stderr + chunk.toString();
       if (combined.length > effectiveStderrMax) {
         stderrTruncated = true;

--- a/tests/spawnCollect.test.ts
+++ b/tests/spawnCollect.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { spawnCollect } from "../src/utils/spawnCollect.js";
+
+// Use the current node binary so these tests work without assuming PATH contents.
+const node = process.execPath;
+const cwd = process.cwd();
+const timeoutMs = 10_000;
+
+describe("spawnCollect — stderr trimming", () => {
+  it("resolves cleanly with small stdout and stderr within limits", async () => {
+    const result = await spawnCollect(
+      node,
+      ["-e", `process.stdout.write("hello stdout"); process.stderr.write("hello stderr");`],
+      { cwd, timeoutMs, maxBuffer: 1024 }
+    );
+    expect(result.stdout).toBe("hello stdout");
+    expect(result.stderr).toBe("hello stderr");
+  });
+
+  it("does not add prefix when stderr fits within maxStderrBuffer", async () => {
+    const result = await spawnCollect(
+      node,
+      ["-e", `process.stderr.write("small");`],
+      { cwd, timeoutMs, maxBuffer: 1024 * 1024, maxStderrBuffer: 1024 }
+    );
+    expect(result.stderr).toBe("small");
+  });
+
+  it("truncates stderr to the tail when it exceeds maxStderrBuffer", async () => {
+    // 200 x's written, limit is 100 — tail should be the last 100 x's
+    const result = await spawnCollect(
+      node,
+      ["-e", `process.stderr.write("x".repeat(200));`],
+      { cwd, timeoutMs, maxBuffer: 1024 * 1024, maxStderrBuffer: 100 }
+    );
+
+    const prefix = "[stderr truncated]\n";
+    expect(result.stderr.startsWith(prefix)).toBe(true);
+    const tail = result.stderr.slice(prefix.length);
+    expect(tail).toBe("x".repeat(100));
+  });
+
+  it("process is NOT killed when stderr exceeds maxStderrBuffer", async () => {
+    // If the process were killed, stdout would be empty and the promise would reject.
+    const result = await spawnCollect(
+      node,
+      ["-e", `process.stderr.write("x".repeat(200)); process.stdout.write("survived");`],
+      { cwd, timeoutMs, maxBuffer: 1024 * 1024, maxStderrBuffer: 100 }
+    );
+    expect(result.stdout).toBe("survived");
+  });
+
+  it("uses the 64 KB default when maxStderrBuffer is omitted", async () => {
+    // 70 KB > 64 KB default — should trigger truncation
+    const result = await spawnCollect(
+      node,
+      ["-e", `process.stderr.write("y".repeat(70 * 1024));`],
+      { cwd, timeoutMs, maxBuffer: 4 * 1024 * 1024 }
+    );
+    expect(result.stderr.startsWith("[stderr truncated]\n")).toBe(true);
+    const tail = result.stderr.slice("[stderr truncated]\n".length);
+    expect(tail.length).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  it("large stderr does not trigger EMSGSIZE (regression: old combined check)", async () => {
+    // Old behaviour: stdout(0) + stderr(150KB) > maxBuffer(100KB) → EMSGSIZE → process killed.
+    // New behaviour: stderr is trimmed independently, stdout never exceeds its limit → resolves.
+    const result = await spawnCollect(
+      node,
+      ["-e", `process.stderr.write("z".repeat(150 * 1024)); process.stdout.write("ok");`],
+      { cwd, timeoutMs, maxBuffer: 100 * 1024, maxStderrBuffer: 64 * 1024 }
+    );
+    expect(result.stdout).toBe("ok");
+    expect(result.stderr.startsWith("[stderr truncated]\n")).toBe(true);
+  });
+
+  it("still throws EMSGSIZE when stdout alone exceeds maxBuffer", async () => {
+    await expect(
+      spawnCollect(
+        node,
+        ["-e", `process.stdout.write("x".repeat(200));`],
+        { cwd, timeoutMs, maxBuffer: 100, maxStderrBuffer: 1024 * 1024 }
+      )
+    ).rejects.toMatchObject({ code: "EMSGSIZE" });
+  });
+
+  it("includes truncation prefix on the stderr field of a non-zero exit error", async () => {
+    const error = await spawnCollect(
+      node,
+      ["-e", `process.stderr.write("e".repeat(200)); process.exit(1);`],
+      { cwd, timeoutMs, maxBuffer: 1024 * 1024, maxStderrBuffer: 100 }
+    ).catch((e: unknown) => e);
+
+    expect(error).toMatchObject({
+      stderr: expect.stringMatching(/^\[stderr truncated\]\n/),
+    });
+  });
+
+  it("includes truncation prefix on the stderr field of a timeout error", async () => {
+    const error = await spawnCollect(
+      node,
+      ["-e", `process.stderr.write("t".repeat(200)); setTimeout(() => {}, 60_000);`],
+      { cwd, timeoutMs: 200, maxBuffer: 1024 * 1024, maxStderrBuffer: 100 }
+    ).catch((e: unknown) => e);
+
+    expect(error).toMatchObject({
+      code: "ETIMEDOUT",
+      stderr: expect.stringMatching(/^\[stderr truncated\]\n/),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Codex emits verbose thought/debug output to stderr, which was counted against the same 4 MB `maxBuffer` as stdout — causing EMSGSIZE and killing the process before the actual reply was received
- `stderr` now has an independent soft-limit (`maxStderrBuffer`, default **64 KB**) that trims to the **tail** when exceeded; the process is never killed by stderr volume alone
- `stdout` retains its existing hard EMSGSIZE limit (4 MB)
- Truncated stderr is prefixed with `[stderr truncated]\n` so debug output remains interpretable in logs
- All existing callers are unaffected — the new option is optional with a sensible default

## Test plan

- [x] 9 new integration tests in `tests/spawnCollect.test.ts` — spawn real `node` child processes to verify truncation, tail content, no false EMSGSIZE from stderr, default 64 KB limit, and truncation prefix on all error paths (non-zero exit, timeout)
- [x] All existing tests pass (`npm test`)
- [x] Type-check passes (`npm run check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)