### PR TITLE
Stop redirecting Docker data-root to the persistent data disk

### DIFF
--- a/infra/startup.sh
+++ b/infra/startup.sh
@@ -22,10 +22,9 @@ fi
 mkdir -p "$DATA_MNT/repos"
 
 # --- Ensure app data is owned by appuser (UID 1001) inside the container ---
-# Chown everything except Docker's data-root which must stay root-owned.
 touch "$DATA_MNT/app.db"
 chown 1001:1001 "$DATA_MNT"
-find "$DATA_MNT" -maxdepth 1 -not -name docker -not -name .swapfile -not -path "$DATA_MNT" -exec chown -R 1001:1001 {} +
+find "$DATA_MNT" -maxdepth 1 -not -name .swapfile -not -path "$DATA_MNT" -exec chown -R 1001:1001 {} +
 
 # --- Swap file on data disk (safety margin for Claude CLI subprocesses) ---
 SWAP="$DATA_MNT/.swapfile"
@@ -41,14 +40,6 @@ swapon "$SWAP" 2>/dev/null || true
 META="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
 HDR="Metadata-Flavor: Google"
 curl -sf -H "$HDR" "$META/env-redeploy-script" > /var/redeploy.sh
-
-# --- Move Docker data-root to the persistent data disk ---
-DOCKER_DATA="$DATA_MNT/docker"
-mkdir -p "$DOCKER_DATA"
-cat > /etc/docker/daemon.json <<DJSON
-{"data-root": "$DOCKER_DATA"}
-DJSON
-systemctl restart docker
 
 # --- Deploy the bot (reuses the same script used for manual redeploys) ---
 bash /var/redeploy.sh


### PR DESCRIPTION
## Summary

- Docker images were being stored on the 10 GB persistent data disk (`/mnt/disks/data/docker`) alongside repos, the SQLite DB, and the swapfile — causing the disk to fill up and blocking image pulls
- Docker images don't need to persist across VM recreation; they're re-pulled on redeploy
- Removed the `daemon.json` data-root override so Docker uses its default path (`/var/lib/docker`) on the COS stateful partition, which has ~5 GB dedicated free space
- The data disk now holds only what genuinely needs to survive VM deletion: `app.db`, `repos/`, `home/appuser/`, and `.swapfile`
- Cleaned up the `-not -name docker` exclusion from the `chown` sweep, which was only there to protect the now-removed Docker directory

## Applying to the live VM (before terraform apply)

The startup script only runs on boot, so apply the change manually on the running VM first:

```bash
sudo docker stop actuarius && sudo docker rm actuarius
sudo rm /etc/docker/daemon.json
sudo systemctl restart docker
sudo rm -rf /mnt/disks/data/docker
sudo bash /var/redeploy.sh
```

Then `terraform apply` will bake the fix permanently into the startup script for future VM recreations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)