### PR TITLE
Add /gh-auth-refresh command and fix auth error logging

### DIFF
--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -2,6 +2,15 @@
 
 Hard-won knowledge from debugging and development. Read this before making changes to avoid repeating past mistakes.
 
+## Recovering from an expired `gh` token on the deployed box
+
+If `gh auth status` shows a 401 inside the `actuarius` container, the GitHub App installation token in `/data/.gh/hosts.yml` is stale. The auth manager's scheduled refresh loop uses pino with the `error` key (instead of `err`), so `error.message` is silently dropped from logs — only the error `code` is visible.
+
+**Recovery options (in order of preference):**
+1. `/gh-auth-refresh` — Discord slash command (requires Manage Server). Force-mints a fresh installation token and re-runs `gh auth login`. Reports the logged-in account name on success.
+2. `docker restart actuarius` — re-runs `initialize()`, which also mints a fresh token. Use when the bot is unreachable via Discord.
+3. If both fail: the GitHub App private key or installation ID is the culprit. Regenerate the private key on GitHub, re-encode it (`base64 -w0 private-key.pem`), update `.env` `GITHUB_APP_PRIVATE_KEY_B64`, and `docker compose up -d --build`.
+
 ## Subprocess stdin must be closed
 
 `execFile`/`promisify` leaves stdin as an open pipe. CLI tools like Claude wait on stdin before running, even with `-p`, causing the process to stall indefinitely.

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -1178,7 +1178,7 @@ export class ActuariusBot {
       await interaction.editReply({ content: `GitHub authentication refreshed. Logged in as \`${login}\`.` });
     } catch (err) {
       this.logger.error({ err }, "gh-auth-refresh failed");
-      const message = err instanceof Error ? err.message : String(err);
+      const message = err instanceof Error ? ((err as any).stderr?.trim() || err.message) : String(err);
       await interaction.editReply({ content: `GitHub authentication refresh failed: ${message}` });
     }
   }

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -27,7 +27,7 @@ import type { AiProvider, RepoRow, RequestStatus } from "../db/types.js";
 import { commandBuilders } from "./commands.js";
 import { buildHelpText } from "./messageTemplates.js";
 import { buildRepoChannelName, buildThreadName } from "./naming.js";
-import { getGitHubCommandEnvironment } from "../services/githubAuthService.js";
+import { forceRefreshGitHubAuth, getGitHubCommandEnvironment } from "../services/githubAuthService.js";
 import {
   GitHubIssueLookupError,
   GitHubRepoLookupError,
@@ -511,6 +511,9 @@ export class ActuariusBot {
         return;
       case "codex-auth":
         await this.handleCodexAuth(interaction);
+        return;
+      case "gh-auth-refresh":
+        await this.handleGhAuthRefresh(interaction);
         return;
       case "delete":
         await this.handleDelete(interaction);
@@ -1151,6 +1154,33 @@ export class ActuariusBot {
       logCommand: "codex-auth",
       successMessage: "Codex credentials saved. `/ask` requests with the Codex provider should now work."
     });
+  }
+
+  private async handleGhAuthRefresh(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!interaction.guild || !interaction.guildId) {
+      await interaction.reply({ content: "This command can only run in a Discord server.", ephemeral: true });
+      return;
+    }
+
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+      await interaction.reply({
+        content: "You need the `Manage Server` permission to refresh GitHub authentication.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      const login = await forceRefreshGitHubAuth();
+      this.logger.info({ login }, "GitHub auth force-refreshed via /gh-auth-refresh");
+      await interaction.editReply({ content: `GitHub authentication refreshed. Logged in as \`${login}\`.` });
+    } catch (err) {
+      this.logger.error({ err }, "gh-auth-refresh failed");
+      const message = err instanceof Error ? err.message : String(err);
+      await interaction.editReply({ content: `GitHub authentication refresh failed: ${message}` });
+    }
   }
 
   private async handleCredentialFileUpload(

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -141,6 +141,9 @@ export const commandBuilders = [
         .setRequired(true)
     ),
   new SlashCommandBuilder()
+    .setName("gh-auth-refresh")
+    .setDescription("Force-refresh the GitHub App authentication token. Requires Manage Server permission."),
+  new SlashCommandBuilder()
     .setName("delete")
     .setDescription("Delete the worktree branch associated with this request thread."),
   new SlashCommandBuilder()
@@ -164,6 +167,7 @@ export type CommandName =
   | "model-current"
   | "review-rounds"
   | "codex-auth"
+  | "gh-auth-refresh"
   | "delete"
   | "review";
 

--- a/src/services/githubAuthService.ts
+++ b/src/services/githubAuthService.ts
@@ -396,11 +396,14 @@ class GitHubAuthManager {
   }
 
   public async forceRefresh(): Promise<string> {
+    if (this.refreshPromise) {
+      await this.refreshPromise;
+    }
     this.cachedInstallationToken = null;
     await this.refreshAuthentication();
     const env = this.getCommandEnvironment();
     const { stdout } = await spawnCollect("gh", ["api", "/user", "-q", ".login"], {
-      cwd: "/",
+      cwd: process.cwd(),
       timeoutMs: GITHUB_AUTH_COMMAND_TIMEOUT_MS,
       maxBuffer: 1024 * 1024,
       env

--- a/src/services/githubAuthService.ts
+++ b/src/services/githubAuthService.ts
@@ -387,12 +387,25 @@ class GitHubAuthManager {
 
     const delay = Math.max(expiresAtMs - Date.now() - TOKEN_REFRESH_BUFFER_MS, TOKEN_REFRESH_RETRY_MS);
     this.refreshTimer = setTimeout(() => {
-      void this.refreshAuthentication().catch((error) => {
-        this.logger.error({ error }, "Failed to refresh GitHub App auth; retrying soon");
+      void this.refreshAuthentication().catch((err) => {
+        this.logger.error({ err }, "Failed to refresh GitHub App auth; retrying soon");
         this.scheduleRefresh(Date.now() + TOKEN_REFRESH_RETRY_MS + TOKEN_REFRESH_BUFFER_MS);
       });
     }, delay);
     this.refreshTimer.unref?.();
+  }
+
+  public async forceRefresh(): Promise<string> {
+    this.cachedInstallationToken = null;
+    await this.refreshAuthentication();
+    const env = this.getCommandEnvironment();
+    const { stdout } = await spawnCollect("gh", ["api", "/user", "-q", ".login"], {
+      cwd: "/",
+      timeoutMs: GITHUB_AUTH_COMMAND_TIMEOUT_MS,
+      maxBuffer: 1024 * 1024,
+      env
+    });
+    return stdout.trim();
   }
 
   private resolveGitIdentity(): GitIdentity | null {
@@ -455,4 +468,11 @@ export async function configureRepositoryGitAuth(localPath: string): Promise<voi
   }
 
   await gitHubAuthManager.configureRepository(localPath);
+}
+
+export async function forceRefreshGitHubAuth(): Promise<string> {
+  if (!gitHubAuthManager) {
+    throw new Error("GitHub auth manager is not initialized.");
+  }
+  return gitHubAuthManager.forceRefresh();
 }


### PR DESCRIPTION
## Summary

- Adds `/gh-auth-refresh` slash command (Manage Server permission required) that force-mints a fresh GitHub App installation token and re-runs `gh auth login` without needing a container restart
- Fixes a pino logging bug: `{ error }` → `{ err }` in the scheduled refresh catch block, so `AUTH_LOGIN_FAILED` log entries now include the actual `gh` stderr message instead of just the error code
- Documents the `gh` token recovery process in `docs/lessons-learned.md`

## Background

The deployed bot's `/data/.gh/hosts.yml` token expired because the scheduled refresh loop was silently failing — the actual `gh` error was dropped from logs due to the pino key mismatch. Without visible error details and no in-band recovery command, the only option was a full container restart.

## Test plan

- [ ] `npm run check` passes (no type errors)
- [ ] `npm test` passes (pre-existing Linux-only failures on Windows unrelated)
- [ ] Deploy and run `/gh-auth-refresh` in a server the bot is in — reply should show `Logged in as actuarius-bot[bot]`
- [ ] Confirm `docker exec actuarius sh -c 'GH_CONFIG_DIR=/data/.gh gh auth status'` shows valid auth after command runs
- [ ] Trigger a deliberate refresh failure and verify the log now shows the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)