### PR TITLE
Add /update-clis slash command for provider CLI updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ infra/terraform.tfstate
 infra/terraform.tfstate.backup
 infra/.terraform.lock.hcl
 infra/*.backup
+
+# MemPalace
+mempalace.yaml

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -521,6 +521,9 @@ export class ActuariusBot {
       case "review":
         await this.handleReview(interaction);
         return;
+      case "update-clis":
+        await this.handleUpdateClis(interaction);
+        return;
       default:
         await interaction.reply({ content: "Unknown command.", ephemeral: true });
     }
@@ -1956,6 +1959,70 @@ Output the result of the command or the link to the created issue.`;
       const message = this.describeExecutionError(error);
       await interaction.channel.send(`**Adversarial review failed**\n\n${clipForDiscord(message, DISCORD_MESSAGE_LIMIT - 40)}`);
       await interaction.editReply(`Review failed: ${message}`);
+    }
+  }
+
+  private async handleUpdateClis(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!interaction.guildId) {
+      await interaction.reply({ content: "This command can only run in a Discord server.", ephemeral: true });
+      return;
+    }
+
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+      await interaction.reply({
+        content: "You need the `Manage Server` permission to update provider CLIs.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    const PROVIDER_PACKAGES: Record<string, string> = {
+      claude: "@anthropic-ai/claude-code",
+      codex: "@openai/codex",
+      gemini: "@google/gemini-cli"
+    };
+
+    const selected = interaction.options.getString("provider") ?? "all";
+    const packages = selected === "all"
+      ? Object.values(PROVIDER_PACKAGES)
+      : PROVIDER_PACKAGES[selected]
+        ? [PROVIDER_PACKAGES[selected]!]
+        : null;
+
+    if (!packages) {
+      await interaction.reply({
+        content: `Unknown provider \`${selected}\`. Use \`claude\`, \`codex\`, \`gemini\`, or omit for all.`,
+        ephemeral: true
+      });
+      return;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      const { spawnCollect } = await import("../utils/spawnCollect.js");
+
+      const label = selected === "all" ? "All provider CLIs" : AI_PROVIDER_LABELS[selected as AiProvider] ?? selected;
+      await interaction.editReply(`Updating ${label} to latest...`);
+
+      const result = await spawnCollect("npm", ["install", "-g", ...packages], {
+        cwd: process.cwd(),
+        env: { ...process.env },
+        timeoutMs: 120_000,
+        maxBuffer: 1024 * 1024
+      });
+
+      const installedList = packages.join(", ");
+      const stderrTrimmed = result.stderr.trim();
+      const body = [`Updated \`${installedList}\` to latest.`];
+      if (stderrTrimmed) {
+        body.push("", "```", stderrTrimmed.slice(0, 1500), "```");
+      }
+      await interaction.editReply(body.join("\n"));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Update failed.";
+      this.logger.error({ error, provider: selected }, "Provider CLI update failed");
+      await interaction.editReply(`Update failed: ${clipForDiscord(message, 1500)}`);
     }
   }
 

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -65,6 +65,12 @@ const AI_PROVIDER_LABELS: Record<AiProvider, string> = {
   gemini: "Gemini"
 };
 
+const PROVIDER_NPM_PACKAGES: Record<string, string> = {
+  claude: "@anthropic-ai/claude-code",
+  codex: "@openai/codex",
+  gemini: "@google/gemini-cli"
+};
+
 function isActiveRequestStatus(status: RequestStatus): boolean {
   return status === "queued" || status === "running" || status === "install_approved" || status === "install_running";
 }
@@ -1976,17 +1982,11 @@ Output the result of the command or the link to the created issue.`;
       return;
     }
 
-    const PROVIDER_PACKAGES: Record<string, string> = {
-      claude: "@anthropic-ai/claude-code",
-      codex: "@openai/codex",
-      gemini: "@google/gemini-cli"
-    };
-
     const selected = interaction.options.getString("provider") ?? "all";
     const packages = selected === "all"
-      ? Object.values(PROVIDER_PACKAGES)
-      : PROVIDER_PACKAGES[selected]
-        ? [PROVIDER_PACKAGES[selected]!]
+      ? Object.values(PROVIDER_NPM_PACKAGES)
+      : PROVIDER_NPM_PACKAGES[selected]
+        ? [PROVIDER_NPM_PACKAGES[selected]!]
         : null;
 
     if (!packages) {
@@ -1999,31 +1999,33 @@ Output the result of the command or the link to the created issue.`;
 
     await interaction.deferReply({ ephemeral: true });
 
-    try {
-      const { spawnCollect } = await import("../utils/spawnCollect.js");
+    const label = selected === "all" ? "All provider CLIs" : AI_PROVIDER_LABELS[selected as AiProvider] ?? selected;
+    await interaction.editReply(`Updating ${label} to latest...`);
 
-      const label = selected === "all" ? "All provider CLIs" : AI_PROVIDER_LABELS[selected as AiProvider] ?? selected;
-      await interaction.editReply(`Updating ${label} to latest...`);
+    this.requestQueue.enqueue(interaction.guildId, async () => {
+      try {
+        const { spawnCollect } = await import("../utils/spawnCollect.js");
 
-      const result = await spawnCollect("npm", ["install", "-g", ...packages], {
-        cwd: process.cwd(),
-        env: { ...process.env },
-        timeoutMs: 120_000,
-        maxBuffer: 1024 * 1024
-      });
+        const result = await spawnCollect("npm", ["install", "-g", ...packages], {
+          cwd: process.cwd(),
+          env: { ...process.env },
+          timeoutMs: 120_000,
+          maxBuffer: 1024 * 1024
+        });
 
-      const installedList = packages.join(", ");
-      const stderrTrimmed = result.stderr.trim();
-      const body = [`Updated \`${installedList}\` to latest.`];
-      if (stderrTrimmed) {
-        body.push("", "```", stderrTrimmed.slice(0, 1500), "```");
+        const installedList = packages.join(", ");
+        const stderrTrimmed = result.stderr.trim();
+        const body = [`Updated \`${installedList}\` to latest.`];
+        if (stderrTrimmed) {
+          body.push("", "```", stderrTrimmed.slice(0, 1500), "```");
+        }
+        await interaction.editReply(body.join("\n"));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Update failed.";
+        this.logger.error({ error, provider: selected }, "Provider CLI update failed");
+        await interaction.editReply(`Update failed: ${clipForDiscord(message, 1500)}`);
       }
-      await interaction.editReply(body.join("\n"));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Update failed.";
-      this.logger.error({ error, provider: selected }, "Provider CLI update failed");
-      await interaction.editReply(`Update failed: ${clipForDiscord(message, 1500)}`);
-    }
+    });
   }
 
   private async runQueuedRequest(input: {

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -148,7 +148,22 @@ export const commandBuilders = [
     .setDescription("Delete the worktree branch associated with this request thread."),
   new SlashCommandBuilder()
     .setName("review")
-    .setDescription("Run adversarial code review for the current request thread.")
+    .setDescription("Run adversarial code review for the current request thread."),
+  new SlashCommandBuilder()
+    .setName("update-clis")
+    .setDescription("Update provider CLIs (claude, codex, gemini) to latest. Requires Manage Server permission.")
+    .addStringOption((option) =>
+      option
+        .setName("provider")
+        .setDescription("Which CLI to update. Omit to update all.")
+        .setRequired(false)
+        .addChoices(
+          { name: "All", value: "all" },
+          { name: "Claude", value: "claude" },
+          { name: "Codex", value: "codex" },
+          { name: "Gemini", value: "gemini" }
+        )
+    )
 ];
 
 export type CommandName =
@@ -169,7 +184,8 @@ export type CommandName =
   | "codex-auth"
   | "gh-auth-refresh"
   | "delete"
-  | "review";
+  | "review"
+  | "update-clis";
 
 export async function registerSlashCommands(config: AppConfig, logger: pino.Logger): Promise<void> {
   const rest = new REST({ version: "10" }).setToken(config.discordToken);

--- a/src/discord/messageTemplates.ts
+++ b/src/discord/messageTemplates.ts
@@ -11,6 +11,7 @@ export function buildHelpText(): string {
     "- `/install [package:<allowed-package-id>] [apt-package:<deb-specs>] scope:<repo|request>` Install an allowlisted tool or apt package (admin only; specify exactly one of `package` or `apt-package`).",
     "- `/review` Run adversarial code review in the current request thread (request owner or Manage Server).",
     "- `/review-rounds [rounds:<number>]` Show or set the max `/review` consensus rounds for this server (admin only to set).",
+    "- `/update-clis [provider:<claude|codex|gemini>]` Update provider CLIs to latest. Omit provider to update all (admin only).",
     "- `/model-select provider:<claude|codex|gemini> model:<name>` Set the AI provider and model for `/ask` (admin only).",
     "- `/model-current` Show the active AI provider and model for this server.",
     "- `/codex-auth credentials:<file>` Upload Codex credentials file from `~/.codex/auth.json` (admin only).",


### PR DESCRIPTION
## Summary

Adds a Discord slash command `/update-clis` that allows server admins to update provider CLIs (claude, codex, gemini) to their latest npm versions without shelling into the container.

**Usage:** `/update-clis` (all) or `/update-clis provider:codex` (single). Requires `Manage Server` permission.

## Changes

| File | Change |
|------|--------|
| `src/discord/commands.ts` | Added `/update-clis` command definition with optional `provider` choice |
| `src/discord/bot.ts` | Added `case "update-clis"` dispatch + `handleUpdateClis()` handler |
| `src/discord/messageTemplates.ts` | Added help text entry |

The handler uses the existing `spawnCollect` utility to run `npm install -g` inside the container, targeting the persistent `/data/home/appuser/.npm-global` prefix.
