### PR TITLE
Add OpenCode (DeepSeek) as an AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ ASK_CONCURRENCY_PER_GUILD=3
 ASK_EXECUTION_TIMEOUT_MS=1200000
 # Required for Gemini execution when ENABLE_GEMINI_EXECUTION=true
 # GEMINI_API_KEY=replace_me
+# Required for OpenCode (DeepSeek) execution when ENABLE_OPENCODE_EXECUTION=true
+# DEEPSEEK_API_KEY=replace_me
 # Optional override for git commits made inside worktrees.
 # If omitted and GitHub App auth is configured, Actuarius derives the bot identity automatically.
 # GIT_USER_NAME=actuarius-bot[bot]

--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,12 @@ ASK_CONCURRENCY_PER_GUILD=3
 ASK_EXECUTION_TIMEOUT_MS=1200000
 # Required for Gemini execution when ENABLE_GEMINI_EXECUTION=true
 # GEMINI_API_KEY=replace_me
-# Required for OpenCode (DeepSeek) execution when ENABLE_OPENCODE_EXECUTION=true
+# Required for OpenCode execution when ENABLE_OPENCODE_EXECUTION=true.
+# Set DEEPSEEK_API_KEY or use /opencode-auth to configure per-guild keys.
+# OpenCode supports any provider/model via --model <provider>/<model>.
 # DEEPSEEK_API_KEY=replace_me
+# OPENAI_API_KEY=replace_me
+# ANTHROPIC_API_KEY=replace_me
 # Optional override for git commits made inside worktrees.
 # If omitted and GitHub App auth is configured, Actuarius derives the bot identity automatically.
 # GIT_USER_NAME=actuarius-bot[bot]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Discord bot container that links GitHub repos to Discord channels and creates re
   - `codex` (seeded into `/data/home/appuser/.npm-global/bin` on first boot)
   - `claude` (seeded into `/data/home/appuser/.npm-global/bin` on first boot)
   - `gemini` (seeded into `/data/home/appuser/.npm-global/bin` on first boot)
+  - `opencode` (seeded into `/data/home/appuser/.npm-global/bin` on first boot)
 - Waits for Discord server invite if not yet in any server.
 - Registers slash commands:
   - `/help`
@@ -61,9 +62,11 @@ Copy `.env.example` to `.env` and set:
 - `ASK_CONCURRENCY_PER_GUILD` (default `3`)
 - `ASK_EXECUTION_TIMEOUT_MS` (default `1200000`)
 - `GEMINI_API_KEY` (required for Gemini execution)
+- `ENABLE_OPENCODE_EXECUTION` (default `false`, enables OpenCode/DeepSeek provider)
+- `DEEPSEEK_API_KEY` (required for OpenCode execution)
 - `CLAUDE_CODE_OAUTH_TOKEN` (optional for local/manual runs, required by the production redeploy helper for non-interactive Claude auth)
 
-Provider CLI auth state is persisted under `/data/home/appuser` inside the container. The provider CLIs themselves are also installed under `/data/home/appuser/.npm-global`, with `docker/entrypoint.sh` seeding them on first boot if missing. That keeps Claude and Codex authentication and CLI updates across container replacement, because production mounts `/data` from the persistent disk. Gemini execution uses `GEMINI_API_KEY` instead of persisted OAuth state.
+Provider CLI auth state is persisted under `/data/home/appuser` inside the container. The provider CLIs themselves are also installed under `/data/home/appuser/.npm-global`, with `docker/entrypoint.sh` seeding them on first boot if missing. That keeps Claude and Codex authentication and CLI updates across container replacement, because production mounts `/data` from the persistent disk. Gemini and OpenCode execution use API keys (`GEMINI_API_KEY` / `DEEPSEEK_API_KEY`) instead of persisted OAuth state.
 
 ## Local development
 

--- a/docker/install-llm-user-instructions.sh
+++ b/docker/install-llm-user-instructions.sh
@@ -13,6 +13,6 @@ install_instruction_file() {
   chmod 0644 "$target_path"
 }
 
-for file in ".claude/CLAUDE.md" ".codex/AGENTS.md" ".gemini/GEMINI.md"; do
+for file in ".claude/CLAUDE.md" ".codex/AGENTS.md" ".gemini/GEMINI.md" ".opencode/AGENTS.md"; do
   install_instruction_file "$SOURCE_ROOT/$file" "$TARGET_HOME/$file"
 done

--- a/docker/llm-user-instructions/.opencode/AGENTS.md
+++ b/docker/llm-user-instructions/.opencode/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+User-level defaults for OpenCode on this machine.
+
+## Scope
+
+- These instructions apply as baseline guidance for any repository on this machine.
+- Repository-local instruction files override these defaults when they provide more specific guidance.
+- System or tool-provided policies remain authoritative over anything in this file.
+
+## Defaults
+
+- Respect repository-local instruction files when they are present.
+- Keep global guidance generic and avoid treating this file as a place for repository-specific architecture or workflow details.
+- Prefer `gh` for GitHub operations when a repository uses GitHub.
+- Use `gh` for author-sensitive GitHub actions such as creating pull requests, posting comments, and replying to review threads so the configured machine identity is used.
+- When addressing pull request review comments, always reply on the review thread after making the requested change unless explicitly told not to.
+- Avoid destructive git commands such as `git reset --hard`, `git checkout --`, or force-pushing unless explicitly requested.
+- Keep changes scoped to the task at hand and do not revert unrelated user changes.
+- Before making non-trivial changes, look for repository guidance such as `AGENTS.md`, `CLAUDE.md`, `README.md`, or nearby docs.
+
+## Precedence
+
+1. System and tool-enforced instructions
+2. Repository-local instruction files
+3. This user-level file

--- a/docker/seed-provider-clis.sh
+++ b/docker/seed-provider-clis.sh
@@ -22,6 +22,7 @@ queue_package_if_missing() {
 queue_package_if_missing "claude" "@anthropic-ai/claude-code"
 queue_package_if_missing "codex" "@openai/codex"
 queue_package_if_missing "gemini" "@google/gemini-cli"
+queue_package_if_missing "opencode" "opencode-ai"
 
 if [ -n "$missing_packages" ]; then
   # Intentionally rely on word splitting so npm receives one package per argument.

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,7 +66,12 @@ const envSchema = z.object({
   ENABLE_GEMINI_EXECUTION: z
     .string()
     .default("false")
-    .transform((value) => value === "true")
+    .transform((value) => value === "true"),
+  ENABLE_OPENCODE_EXECUTION: z
+    .string()
+    .default("false")
+    .transform((value) => value === "true"),
+  DEEPSEEK_API_KEY: optionalNonEmpty,
 });
 
 const parsed = envSchema.safeParse(process.env);
@@ -130,7 +135,9 @@ export const appConfig = {
   installStepTimeoutMs: rawConfig.INSTALL_STEP_TIMEOUT_MS,
   aptInstallHelperPath: rawConfig.APT_INSTALL_HELPER_PATH,
   enableCodexExecution: rawConfig.ENABLE_CODEX_EXECUTION,
-  enableGeminiExecution: rawConfig.ENABLE_GEMINI_EXECUTION
+  enableGeminiExecution: rawConfig.ENABLE_GEMINI_EXECUTION,
+  enableOpencodeExecution: rawConfig.ENABLE_OPENCODE_EXECUTION,
+  deepseekApiKey: rawConfig.DEEPSEEK_API_KEY,
 };
 
 export type AppConfig = typeof appConfig;

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -5,7 +5,7 @@ export interface GuildRow {
   updated_at: string;
 }
 
-export type AiProvider = "claude" | "codex" | "gemini";
+export type AiProvider = "claude" | "codex" | "gemini" | "opencode";
 
 export interface GuildModelConfigRow {
   guild_id: string;

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -70,7 +70,8 @@ const AI_PROVIDER_LABELS: Record<AiProvider, string> = {
 const PROVIDER_NPM_PACKAGES: Record<string, string> = {
   claude: "@anthropic-ai/claude-code",
   codex: "@openai/codex",
-  gemini: "@google/gemini-cli"
+  gemini: "@google/gemini-cli",
+  opencode: "opencode-ai"
 };
 
 const KNOWN_MODELS_BY_PROVIDER: Partial<Record<AiProvider, string[]>> = {
@@ -2031,7 +2032,7 @@ Output the result of the command or the link to the created issue.`;
 
     if (!packages) {
       await interaction.reply({
-        content: `Unknown provider \`${selected}\`. Use \`claude\`, \`codex\`, \`gemini\`, or omit for all.`,
+        content: `Unknown provider \`${selected}\`. Use \`claude\`, \`codex\`, \`gemini\`, \`opencode\`, or omit for all.`,
         ephemeral: true
       });
       return;

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -77,7 +77,7 @@ const KNOWN_MODELS_BY_PROVIDER: Partial<Record<AiProvider, string[]>> = {
   claude: ["claude-sonnet-4-6", "claude-haiku-4-5", "claude-opus-4-6"],
   codex: ["o4-mini", "o4", "gpt-5.2"],
   gemini: ["gemini-2.5-pro", "gemini-2.0-flash"],
-  opencode: ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-chat"]
+  opencode: ["deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-flash", "deepseek/deepseek-chat", "deepseek/deepseek-reasoner"]
 };
 
 function isActiveRequestStatus(status: RequestStatus): boolean {

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -52,6 +52,7 @@ import {
 import { ClaudeExecutionError, runClaudeRequest } from "../services/claudeExecutionService.js";
 import { CodexExecutionError, runCodexRequest } from "../services/codexExecutionService.js";
 import { GeminiExecutionError, runGeminiRequest } from "../services/geminiExecutionService.js";
+import { OpencodeExecutionError, runOpencodeRequest } from "../services/opencodeExecutionService.js";
 import { RequestExecutionQueue } from "../services/requestExecutionQueue.js";
 import { InstallService, InstallServiceError } from "../services/installService.js";
 import { buildAptPackageId, getAptPackageSpec, isAptPackageId } from "../services/installerRegistry.js";
@@ -62,7 +63,8 @@ const DISCORD_MESSAGE_LIMIT = 2_000;
 const AI_PROVIDER_LABELS: Record<AiProvider, string> = {
   claude: "Claude",
   codex: "Codex",
-  gemini: "Gemini"
+  gemini: "Gemini",
+  opencode: "OpenCode"
 };
 
 const PROVIDER_NPM_PACKAGES: Record<string, string> = {
@@ -1077,6 +1079,22 @@ export class ActuariusBot {
       return;
     }
 
+    if (provider === "opencode" && !this.config.enableOpencodeExecution) {
+      await interaction.reply({
+        content: "OpenCode execution is not enabled on this instance (`ENABLE_OPENCODE_EXECUTION` is not set). Choose a different provider or ask the instance administrator to enable it.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    if (provider === "opencode" && !this.config.deepseekApiKey?.trim()) {
+      await interaction.reply({
+        content: "OpenCode execution requires `DEEPSEEK_API_KEY` on this instance. Choose a different provider or ask the instance administrator to configure it.",
+        ephemeral: true
+      });
+      return;
+    }
+
     this.db.upsertGuild(interaction.guild.id, interaction.guild.name);
     this.db.setGuildModelConfig(interaction.guildId, provider, model, interaction.user.id);
 
@@ -1700,7 +1718,7 @@ Output the result of the command or the link to the created issue.`;
     const preferredProvider: AiProvider = modelConfig?.provider ?? "claude";
     const preferredModel = modelConfig?.model ?? undefined;
     const providers: AiProvider[] = [preferredProvider];
-    for (const candidate of ["claude", "codex", "gemini"] satisfies AiProvider[]) {
+    for (const candidate of ["claude", "codex", "gemini", "opencode"] satisfies AiProvider[]) {
       if (!providers.includes(candidate)) {
         providers.push(candidate);
       }
@@ -1723,6 +1741,9 @@ Output the result of the command or the link to the created issue.`;
         continue;
       }
       if (provider === "gemini" && !this.config.enableGeminiExecution) {
+        continue;
+      }
+      if (provider === "opencode" && !this.config.enableOpencodeExecution) {
         continue;
       }
 
@@ -1790,6 +1811,17 @@ Output the result of the command or the link to the created issue.`;
         }
 
         const result = await runGeminiRequest(request, this.logger);
+        return result.text;
+      }
+      case "opencode": {
+        if (!this.config.enableOpencodeExecution) {
+          throw new OpencodeExecutionError(
+            "OPENCODE_DISABLED",
+            "The server's configured AI provider (OpenCode) is currently disabled. An admin can switch providers with `/model-select`."
+          );
+        }
+
+        const result = await runOpencodeRequest(request, this.logger);
         return result.text;
       }
       case "claude":
@@ -2190,6 +2222,10 @@ Output the result of the command or the link to the created issue.`;
     }
 
     if (error instanceof GeminiExecutionError) {
+      return error.message;
+    }
+
+    if (error instanceof OpencodeExecutionError) {
       return error.message;
     }
 

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -73,6 +73,13 @@ const PROVIDER_NPM_PACKAGES: Record<string, string> = {
   gemini: "@google/gemini-cli"
 };
 
+const KNOWN_MODELS_BY_PROVIDER: Partial<Record<AiProvider, string[]>> = {
+  claude: ["claude-sonnet-4-6", "claude-haiku-4-5", "claude-opus-4-6"],
+  codex: ["o4-mini", "o4", "gpt-5.2"],
+  gemini: ["gemini-2.5-pro", "gemini-2.0-flash"],
+  opencode: ["deepseek-v4-pro", "deepseek-v4-flash", "deepseek-chat"]
+};
+
 function isActiveRequestStatus(status: RequestStatus): boolean {
   return status === "queued" || status === "running" || status === "install_approved" || status === "install_running";
 }
@@ -1015,13 +1022,14 @@ export class ActuariusBot {
     }
 
     const history = this.db.getModelHistory(provider as AiProvider);
+    const candidates = history.length > 0 ? history : KNOWN_MODELS_BY_PROVIDER[provider as AiProvider] ?? [];
     const typed = focused.value.toLowerCase();
     const filtered = typed
-      ? history.filter((m) => m.toLowerCase().includes(typed))
-      : history;
+      ? candidates.filter((m) => m.toLowerCase().includes(typed))
+      : candidates;
 
     await interaction.respond(
-      filtered.map((model) => ({ name: model, value: model }))
+      filtered.slice(0, 10).map((model) => ({ name: model, value: model }))
     );
   }
 

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -1115,7 +1115,7 @@ export class ActuariusBot {
       return;
     }
 
-    if (provider === "opencode" && !this.config.deepseekApiKey?.trim() && !hasOpencodeAuth()) {
+    if (provider === "opencode" && !this.config.deepseekApiKey?.trim() && !(await hasOpencodeAuth())) {
       await interaction.reply({
         content: "OpenCode execution requires an API key. Use `/opencode-auth` to configure keys (e.g. `deepseek`, `openai`, `anthropic`), or set `DEEPSEEK_API_KEY` on the instance.",
         ephemeral: true

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -52,7 +52,7 @@ import {
 import { ClaudeExecutionError, runClaudeRequest } from "../services/claudeExecutionService.js";
 import { CodexExecutionError, runCodexRequest } from "../services/codexExecutionService.js";
 import { GeminiExecutionError, runGeminiRequest } from "../services/geminiExecutionService.js";
-import { OpencodeExecutionError, runOpencodeRequest } from "../services/opencodeExecutionService.js";
+import { OpencodeExecutionError, runOpencodeRequest, hasOpencodeAuth } from "../services/opencodeExecutionService.js";
 import { RequestExecutionQueue } from "../services/requestExecutionQueue.js";
 import { InstallService, InstallServiceError } from "../services/installService.js";
 import { buildAptPackageId, getAptPackageSpec, isAptPackageId } from "../services/installerRegistry.js";
@@ -78,7 +78,20 @@ const KNOWN_MODELS_BY_PROVIDER: Partial<Record<AiProvider, string[]>> = {
   claude: ["claude-sonnet-4-6", "claude-haiku-4-5", "claude-opus-4-6"],
   codex: ["o4-mini", "o4", "gpt-5.2"],
   gemini: ["gemini-2.5-pro", "gemini-2.0-flash"],
-  opencode: ["deepseek/deepseek-v4-pro", "deepseek/deepseek-v4-flash", "deepseek/deepseek-chat", "deepseek/deepseek-reasoner"]
+  opencode: [
+    "deepseek/deepseek-v4-pro",
+    "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-chat",
+    "deepseek/deepseek-reasoner",
+    "openai/o4-mini",
+    "openai/o4",
+    "openai/gpt-5.2",
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-haiku-4-5",
+    "anthropic/claude-opus-4-6",
+    "google/gemini-2.5-pro",
+    "google/gemini-2.0-flash"
+  ]
 };
 
 function isActiveRequestStatus(status: RequestStatus): boolean {
@@ -527,6 +540,12 @@ export class ActuariusBot {
         return;
       case "codex-auth":
         await this.handleCodexAuth(interaction);
+        return;
+      case "opencode-auth":
+        await this.handleOpencodeAuth(interaction);
+        return;
+      case "opencode-auth-remove":
+        await this.handleOpencodeAuthRemove(interaction);
         return;
       case "gh-auth-refresh":
         await this.handleGhAuthRefresh(interaction);
@@ -1023,7 +1042,7 @@ export class ActuariusBot {
     }
 
     const history = this.db.getModelHistory(provider as AiProvider);
-    const candidates = history.length > 0 ? history : KNOWN_MODELS_BY_PROVIDER[provider as AiProvider] ?? [];
+    const candidates = [...new Set([...history, ...(KNOWN_MODELS_BY_PROVIDER[provider as AiProvider] ?? [])])];
     const typed = focused.value.toLowerCase();
     const filtered = typed
       ? candidates.filter((m) => m.toLowerCase().includes(typed))
@@ -1096,9 +1115,9 @@ export class ActuariusBot {
       return;
     }
 
-    if (provider === "opencode" && !this.config.deepseekApiKey?.trim()) {
+    if (provider === "opencode" && !this.config.deepseekApiKey?.trim() && !hasOpencodeAuth()) {
       await interaction.reply({
-        content: "OpenCode execution requires `DEEPSEEK_API_KEY` on this instance. Choose a different provider or ask the instance administrator to configure it.",
+        content: "OpenCode execution requires an API key. Use `/opencode-auth` to configure keys (e.g. `deepseek`, `openai`, `anthropic`), or set `DEEPSEEK_API_KEY` on the instance.",
         ephemeral: true
       });
       return;
@@ -1189,6 +1208,150 @@ export class ActuariusBot {
       logLabel: "Codex credentials written",
       logCommand: "codex-auth",
       successMessage: "Codex credentials saved. `/ask` requests with the Codex provider should now work."
+    });
+  }
+
+  private async handleOpencodeAuth(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!interaction.guild || !interaction.guildId) {
+      await interaction.reply({ content: "This command can only run in a Discord server.", ephemeral: true });
+      return;
+    }
+
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+      await interaction.reply({
+        content: "You need the `Manage Server` permission to configure OpenCode API keys.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    if (!this.config.enableOpencodeExecution) {
+      await interaction.reply({
+        content: "OpenCode execution is not enabled on this instance. Set `ENABLE_OPENCODE_EXECUTION=true` to enable it.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    const rawProvider = interaction.options.getString("provider", true);
+    const rawKey = interaction.options.getString("key", true);
+    const apiKey = rawKey.trim();
+
+    if (!apiKey) {
+      await interaction.reply({ content: "API key cannot be empty.", ephemeral: true });
+      return;
+    }
+
+    const allowedProviders = ["deepseek", "openai", "anthropic", "google", "xai", "groq", "openrouter", "together"];
+
+    if (!allowedProviders.includes(rawProvider)) {
+      await interaction.reply({
+        content: `Invalid provider. Choose from: \`${allowedProviders.join("`, `")}\`.`,
+        ephemeral: true
+      });
+      return;
+    }
+
+    const authPath = join(homedir(), ".local", "share", "opencode", "auth.json");
+    const { readFile } = await import("node:fs/promises");
+    const { existsSync: localExistsSync } = await import("node:fs");
+
+    let authJson: Record<string, { type: string; key: string }> = {};
+
+    if (localExistsSync(authPath)) {
+      try {
+        const raw = await readFile(authPath, "utf-8");
+        authJson = JSON.parse(raw) as typeof authJson;
+      } catch {
+        // Start fresh if the file is malformed
+      }
+    }
+
+    authJson[rawProvider] = { type: "api", key: apiKey };
+
+    await mkdir(dirname(authPath), { recursive: true });
+    await writeFile(authPath, JSON.stringify(authJson, null, 2) + "\n", { mode: 0o600 });
+
+    this.logger.info({ guildId: interaction.guildId, provider: rawProvider }, "OpenCode auth key saved");
+
+    await interaction.reply({
+      content: `API key for **${rawProvider}** saved to OpenCode's auth.json. All \`/ask\` requests with the OpenCode provider can now use this key.`,
+      ephemeral: true
+    });
+  }
+
+  private async handleOpencodeAuthRemove(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!interaction.guild || !interaction.guildId) {
+      await interaction.reply({ content: "This command can only run in a Discord server.", ephemeral: true });
+      return;
+    }
+
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+      await interaction.reply({
+        content: "You need the `Manage Server` permission to remove OpenCode API keys.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    const rawProvider = interaction.options.getString("provider", true);
+
+    const allowedProviders = ["deepseek", "openai", "anthropic", "google", "xai", "groq", "openrouter", "together"];
+
+    if (!allowedProviders.includes(rawProvider)) {
+      await interaction.reply({
+        content: `Invalid provider. Choose from: \`${allowedProviders.join("`, `")}\`.`,
+        ephemeral: true
+      });
+      return;
+    }
+
+    const authPath = join(homedir(), ".local", "share", "opencode", "auth.json");
+    const { readFile } = await import("node:fs/promises");
+    const { existsSync: localExistsSync } = await import("node:fs");
+
+    if (!localExistsSync(authPath)) {
+      await interaction.reply({
+        content: `No stored auth.json found. No keys to remove.`,
+        ephemeral: true
+      });
+      return;
+    }
+
+    let authJson: Record<string, unknown> = {};
+    try {
+      const raw = await readFile(authPath, "utf-8");
+      authJson = JSON.parse(raw) as typeof authJson;
+    } catch {
+      await interaction.reply({
+        content: "OpenCode auth.json is malformed. Delete it manually and re-configure keys.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    if (!(rawProvider in authJson)) {
+      await interaction.reply({
+        content: `No stored API key for **${rawProvider}**.`,
+        ephemeral: true
+      });
+      return;
+    }
+
+    delete authJson[rawProvider];
+
+    if (Object.keys(authJson).length === 0) {
+      const { unlink } = await import("node:fs/promises");
+      await unlink(authPath);
+    } else {
+      await writeFile(authPath, JSON.stringify(authJson, null, 2) + "\n", { mode: 0o600 });
+    }
+
+    this.logger.info({ guildId: interaction.guildId, provider: rawProvider }, "OpenCode auth key removed");
+
+    await interaction.reply({
+      content: `API key for **${rawProvider}** has been removed from OpenCode's auth.json.`,
+      ephemeral: true
     });
   }
 

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import {
@@ -52,7 +52,7 @@ import {
 import { ClaudeExecutionError, runClaudeRequest } from "../services/claudeExecutionService.js";
 import { CodexExecutionError, runCodexRequest } from "../services/codexExecutionService.js";
 import { GeminiExecutionError, runGeminiRequest } from "../services/geminiExecutionService.js";
-import { OpencodeExecutionError, runOpencodeRequest, hasOpencodeAuth } from "../services/opencodeExecutionService.js";
+import { OpencodeExecutionError, runOpencodeRequest, hasOpencodeAuth, OPENCODE_AUTH_PATH, ALLOWED_OPENCODE_PROVIDERS } from "../services/opencodeExecutionService.js";
 import { RequestExecutionQueue } from "../services/requestExecutionQueue.js";
 import { InstallService, InstallServiceError } from "../services/installService.js";
 import { buildAptPackageId, getAptPackageSpec, isAptPackageId } from "../services/installerRegistry.js";
@@ -1242,25 +1242,19 @@ export class ActuariusBot {
       return;
     }
 
-    const allowedProviders = ["deepseek", "openai", "anthropic", "google", "xai", "groq", "openrouter", "together"];
-
-    if (!allowedProviders.includes(rawProvider)) {
+    if (!ALLOWED_OPENCODE_PROVIDERS.includes(rawProvider as typeof ALLOWED_OPENCODE_PROVIDERS[number])) {
       await interaction.reply({
-        content: `Invalid provider. Choose from: \`${allowedProviders.join("`, `")}\`.`,
+        content: `Invalid provider. Choose from: \`${ALLOWED_OPENCODE_PROVIDERS.join("`, `")}\`.`,
         ephemeral: true
       });
       return;
     }
 
-    const authPath = join(homedir(), ".local", "share", "opencode", "auth.json");
-    const { readFile } = await import("node:fs/promises");
-    const { existsSync: localExistsSync } = await import("node:fs");
-
     let authJson: Record<string, { type: string; key: string }> = {};
 
-    if (localExistsSync(authPath)) {
+    if (existsSync(OPENCODE_AUTH_PATH)) {
       try {
-        const raw = await readFile(authPath, "utf-8");
+        const raw = await readFile(OPENCODE_AUTH_PATH, "utf-8");
         authJson = JSON.parse(raw) as typeof authJson;
       } catch {
         // Start fresh if the file is malformed
@@ -1269,8 +1263,8 @@ export class ActuariusBot {
 
     authJson[rawProvider] = { type: "api", key: apiKey };
 
-    await mkdir(dirname(authPath), { recursive: true });
-    await writeFile(authPath, JSON.stringify(authJson, null, 2) + "\n", { mode: 0o600 });
+    await mkdir(dirname(OPENCODE_AUTH_PATH), { recursive: true });
+    await writeFile(OPENCODE_AUTH_PATH, JSON.stringify(authJson, null, 2) + "\n", { mode: 0o600 });
 
     this.logger.info({ guildId: interaction.guildId, provider: rawProvider }, "OpenCode auth key saved");
 
@@ -1296,21 +1290,15 @@ export class ActuariusBot {
 
     const rawProvider = interaction.options.getString("provider", true);
 
-    const allowedProviders = ["deepseek", "openai", "anthropic", "google", "xai", "groq", "openrouter", "together"];
-
-    if (!allowedProviders.includes(rawProvider)) {
+    if (!ALLOWED_OPENCODE_PROVIDERS.includes(rawProvider as typeof ALLOWED_OPENCODE_PROVIDERS[number])) {
       await interaction.reply({
-        content: `Invalid provider. Choose from: \`${allowedProviders.join("`, `")}\`.`,
+        content: `Invalid provider. Choose from: \`${ALLOWED_OPENCODE_PROVIDERS.join("`, `")}\`.`,
         ephemeral: true
       });
       return;
     }
 
-    const authPath = join(homedir(), ".local", "share", "opencode", "auth.json");
-    const { readFile } = await import("node:fs/promises");
-    const { existsSync: localExistsSync } = await import("node:fs");
-
-    if (!localExistsSync(authPath)) {
+    if (!existsSync(OPENCODE_AUTH_PATH)) {
       await interaction.reply({
         content: `No stored auth.json found. No keys to remove.`,
         ephemeral: true
@@ -1320,7 +1308,7 @@ export class ActuariusBot {
 
     let authJson: Record<string, unknown> = {};
     try {
-      const raw = await readFile(authPath, "utf-8");
+      const raw = await readFile(OPENCODE_AUTH_PATH, "utf-8");
       authJson = JSON.parse(raw) as typeof authJson;
     } catch {
       await interaction.reply({
@@ -1341,10 +1329,9 @@ export class ActuariusBot {
     delete authJson[rawProvider];
 
     if (Object.keys(authJson).length === 0) {
-      const { unlink } = await import("node:fs/promises");
-      await unlink(authPath);
+      await unlink(OPENCODE_AUTH_PATH);
     } else {
-      await writeFile(authPath, JSON.stringify(authJson, null, 2) + "\n", { mode: 0o600 });
+      await writeFile(OPENCODE_AUTH_PATH, JSON.stringify(authJson, null, 2) + "\n", { mode: 0o600 });
     }
 
     this.logger.info({ guildId: interaction.guildId, provider: rawProvider }, "OpenCode auth key removed");

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -108,7 +108,8 @@ export const commandBuilders = [
         .addChoices(
           { name: "Claude", value: "claude" },
           { name: "Codex", value: "codex" },
-          { name: "Gemini", value: "gemini" }
+          { name: "Gemini", value: "gemini" },
+          { name: "OpenCode (DeepSeek)", value: "opencode" }
         )
     )
     .addStringOption((option) =>

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -143,7 +143,7 @@ export const commandBuilders = [
     ),
   new SlashCommandBuilder()
     .setName("opencode-auth")
-    .setDescription("Configure an API key for OpenCode to use with a specific AI provider. Requires Manage Server permission.")
+    .setDescription("Configure an API key for OpenCode (e.g. deepseek, openai). Requires Manage Server permission.")
     .addStringOption((option) =>
       option
         .setName("provider")

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -196,7 +196,7 @@ export const commandBuilders = [
     .setDescription("Run adversarial code review for the current request thread."),
   new SlashCommandBuilder()
     .setName("update-clis")
-    .setDescription("Update provider CLIs (claude, codex, gemini) to latest. Requires Manage Server permission.")
+    .setDescription("Update provider CLIs (claude, codex, gemini, opencode) to latest. Requires Manage Server permission.")
     .addStringOption((option) =>
       option
         .setName("provider")
@@ -206,7 +206,8 @@ export const commandBuilders = [
           { name: "All", value: "all" },
           { name: "Claude", value: "claude" },
           { name: "Codex", value: "codex" },
-          { name: "Gemini", value: "gemini" }
+          { name: "Gemini", value: "gemini" },
+          { name: "OpenCode", value: "opencode" }
         )
     )
 ];

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -142,6 +142,50 @@ export const commandBuilders = [
         .setRequired(true)
     ),
   new SlashCommandBuilder()
+    .setName("opencode-auth")
+    .setDescription("Configure an API key for OpenCode to use with a specific AI provider. Requires Manage Server permission.")
+    .addStringOption((option) =>
+      option
+        .setName("provider")
+        .setDescription("AI provider to configure the key for (e.g. deepseek, openai, anthropic)")
+        .setRequired(true)
+        .addChoices(
+          { name: "DeepSeek", value: "deepseek" },
+          { name: "OpenAI", value: "openai" },
+          { name: "Anthropic", value: "anthropic" },
+          { name: "Google", value: "google" },
+          { name: "xAI", value: "xai" },
+          { name: "Groq", value: "groq" },
+          { name: "OpenRouter", value: "openrouter" },
+          { name: "Together", value: "together" }
+        )
+    )
+    .addStringOption((option) =>
+      option
+        .setName("key")
+        .setDescription("Your API key for the selected provider")
+        .setRequired(true)
+    ),
+  new SlashCommandBuilder()
+    .setName("opencode-auth-remove")
+    .setDescription("Remove a stored API key for OpenCode. Requires Manage Server permission.")
+    .addStringOption((option) =>
+      option
+        .setName("provider")
+        .setDescription("AI provider to remove the key for")
+        .setRequired(true)
+        .addChoices(
+          { name: "DeepSeek", value: "deepseek" },
+          { name: "OpenAI", value: "openai" },
+          { name: "Anthropic", value: "anthropic" },
+          { name: "Google", value: "google" },
+          { name: "xAI", value: "xai" },
+          { name: "Groq", value: "groq" },
+          { name: "OpenRouter", value: "openrouter" },
+          { name: "Together", value: "together" }
+        )
+    ),
+  new SlashCommandBuilder()
     .setName("gh-auth-refresh")
     .setDescription("Force-refresh the GitHub App authentication token. Requires Manage Server permission."),
   new SlashCommandBuilder()
@@ -183,6 +227,8 @@ export type CommandName =
   | "model-current"
   | "review-rounds"
   | "codex-auth"
+  | "opencode-auth"
+  | "opencode-auth-remove"
   | "gh-auth-refresh"
   | "delete"
   | "review"

--- a/src/discord/messageTemplates.ts
+++ b/src/discord/messageTemplates.ts
@@ -12,7 +12,7 @@ export function buildHelpText(): string {
     "- `/review` Run adversarial code review in the current request thread (request owner or Manage Server).",
     "- `/review-rounds [rounds:<number>]` Show or set the max `/review` consensus rounds for this server (admin only to set).",
     "- `/update-clis [provider:<claude|codex|gemini>]` Update provider CLIs to latest. Omit provider to update all (admin only).",
-    "- `/model-select provider:<claude|codex|gemini> model:<name>` Set the AI provider and model for `/ask` (admin only).",
+    "- `/model-select provider:<claude|codex|gemini|opencode> model:<name>` Set the AI provider and model for `/ask` (admin only).",
     "- `/model-current` Show the active AI provider and model for this server.",
     "- `/codex-auth credentials:<file>` Upload Codex credentials file from `~/.codex/auth.json` (admin only).",
     "",
@@ -20,6 +20,7 @@ export function buildHelpText(): string {
     "- Private repos work when the configured GitHub identity can access them.",
     "- `/ask` uses queued AI execution with per-guild concurrency limits.",
     "- Codex and Gemini require `ENABLE_CODEX_EXECUTION` / `ENABLE_GEMINI_EXECUTION` to be enabled.",
-    "- Gemini additionally requires `GEMINI_API_KEY`."
+    "- Gemini additionally requires `GEMINI_API_KEY`.",
+    "- OpenCode requires `ENABLE_OPENCODE_EXECUTION` and `DEEPSEEK_API_KEY`."
   ].join("\n");
 }

--- a/src/discord/messageTemplates.ts
+++ b/src/discord/messageTemplates.ts
@@ -15,12 +15,15 @@ export function buildHelpText(): string {
     "- `/model-select provider:<claude|codex|gemini|opencode> model:<name>` Set the AI provider and model for `/ask` (admin only).",
     "- `/model-current` Show the active AI provider and model for this server.",
     "- `/codex-auth credentials:<file>` Upload Codex credentials file from `~/.codex/auth.json` (admin only).",
+    "- `/opencode-auth provider:<name> key:<your-key>` Configure an API key for OpenCode to use with a specific AI provider (admin only).",
+    "- `/opencode-auth-remove provider:<name>` Remove a stored API key for OpenCode (admin only).",
     "",
     "v1 notes:",
     "- Private repos work when the configured GitHub identity can access them.",
     "- `/ask` uses queued AI execution with per-guild concurrency limits.",
     "- Codex and Gemini require `ENABLE_CODEX_EXECUTION` / `ENABLE_GEMINI_EXECUTION` to be enabled.",
     "- Gemini additionally requires `GEMINI_API_KEY`.",
-    "- OpenCode requires `ENABLE_OPENCODE_EXECUTION` and `DEEPSEEK_API_KEY`."
+    "- OpenCode requires `ENABLE_OPENCODE_EXECUTION` and API keys. Use `/opencode-auth` to configure per-provider keys (deepseek, openai, anthropic, etc.) or set the relevant env vars on the instance.",
+    "- OpenCode supports any provider/model combination via `--model <provider>/<model>`, e.g. `deepseek/deepseek-v4-pro`, `openai/o4-mini`, `anthropic/claude-sonnet-4-6`."
   ].join("\n");
 }

--- a/src/services/capabilityService.ts
+++ b/src/services/capabilityService.ts
@@ -14,7 +14,8 @@ const checks: CapabilityCheck[] = [
   { capability: "npm", command: "npm", args: ["--version"] },
   { capability: "codex", command: "codex", args: ["--version"] },
   { capability: "claude", command: "claude", args: ["--version"] },
-  { capability: "gemini", command: "gemini", args: ["--version"] }
+  { capability: "gemini", command: "gemini", args: ["--version"] },
+  { capability: "opencode", command: "opencode", args: ["--version"] }
 ];
 
 export function runCapabilityChecks(logger: pino.Logger): void {

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -1,0 +1,51 @@
+import type { Logger } from "pino";
+import { runProviderRequest } from "../utils/runProviderRequest.js";
+
+export interface OpencodeExecutionInput {
+  prompt: string;
+  cwd: string;
+  timeoutMs: number;
+  model?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface OpencodeExecutionResult {
+  text: string;
+}
+
+export class OpencodeExecutionError extends Error {
+  public readonly code: "OPENCODE_UNAVAILABLE" | "OPENCODE_DISABLED" | "NOT_AUTHENTICATED" | "TIMEOUT" | "FAILED" | "EMPTY_OUTPUT";
+
+  public constructor(code: "OPENCODE_UNAVAILABLE" | "OPENCODE_DISABLED" | "NOT_AUTHENTICATED" | "TIMEOUT" | "FAILED" | "EMPTY_OUTPUT", message: string) {
+    super(message);
+    this.name = "OpencodeExecutionError";
+    this.code = code;
+  }
+}
+
+export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: Logger): Promise<OpencodeExecutionResult> {
+  if (!process.env.DEEPSEEK_API_KEY?.trim()) {
+    throw new OpencodeExecutionError("NOT_AUTHENTICATED", "Opencode requires `DEEPSEEK_API_KEY` to be set for DeepSeek API access.");
+  }
+
+  const text = await runProviderRequest(
+    input,
+    {
+      binary: "opencode",
+      prefixArgs: ["run"],
+      positionalPrompt: true,
+      extraArgs: ["--dangerously-skip-permissions", "--format", "json"],
+      logLabel: "OpenCode",
+      makeError: (code, message) => new OpencodeExecutionError(code as OpencodeExecutionError["code"], message),
+      unavailableCode: "OPENCODE_UNAVAILABLE",
+      notAuthenticatedCode: "NOT_AUTHENTICATED",
+      authFailurePattern: /not authenticated|API key not found|authentication required|set an Auth method/i,
+      authHint: "Set `DEEPSEEK_API_KEY` to a valid DeepSeek API key.",
+      timeoutCode: "TIMEOUT",
+      failedCode: "FAILED",
+      emptyOutputCode: "EMPTY_OUTPUT",
+    },
+    logger
+  );
+  return { text };
+}

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -36,7 +36,7 @@ export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: 
       binary: "opencode",
       prefixArgs: ["run"],
       positionalPrompt: true,
-      extraArgs: ["--dangerously-skip-permissions", "--format", "json"],
+      extraArgs: ["--dangerously-skip-permissions"],
       logLabel: "OpenCode",
       makeError: (code, message) => new OpencodeExecutionError(code as OpencodeExecutionError["code"], message),
       unavailableCode: "OPENCODE_UNAVAILABLE",

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -28,8 +28,11 @@ export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: 
     throw new OpencodeExecutionError("NOT_AUTHENTICATED", "Opencode requires `DEEPSEEK_API_KEY` to be set for DeepSeek API access.");
   }
 
+  // opencode --model expects bare model IDs (e.g. deepseek-v4-pro) without a provider prefix.
+  // Omitting --model lets opencode use its configured default model.
+  const { model: _model, ...inputWithoutModel } = input;
   const text = await runProviderRequest(
-    input,
+    inputWithoutModel,
     {
       binary: "opencode",
       prefixArgs: ["run"],

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -30,9 +30,8 @@ export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: 
 
   // opencode --model expects bare model IDs (e.g. deepseek-v4-pro) without a provider prefix.
   // Omitting --model lets opencode use its configured default model.
-  const { model: _model, ...inputWithoutModel } = input;
   const text = await runProviderRequest(
-    inputWithoutModel,
+    input,
     {
       binary: "opencode",
       prefixArgs: ["run"],

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -24,12 +24,10 @@ export class OpencodeExecutionError extends Error {
 }
 
 export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: Logger): Promise<OpencodeExecutionResult> {
-  if (!process.env.DEEPSEEK_API_KEY?.trim()) {
+  const apiKey = input.env?.DEEPSEEK_API_KEY || process.env.DEEPSEEK_API_KEY;
+  if (!apiKey?.trim()) {
     throw new OpencodeExecutionError("NOT_AUTHENTICATED", "Opencode requires `DEEPSEEK_API_KEY` to be set for DeepSeek API access.");
   }
-
-  // opencode --model expects bare model IDs (e.g. deepseek-v4-pro) without a provider prefix.
-  // Omitting --model lets opencode use its configured default model.
   const text = await runProviderRequest(
     input,
     {

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -5,6 +5,9 @@ import { homedir } from "node:os";
 import type { Logger } from "pino";
 import { runProviderRequest } from "../utils/runProviderRequest.js";
 
+export const ALLOWED_OPENCODE_PROVIDERS = ["deepseek", "openai", "anthropic", "google", "xai", "groq", "openrouter", "together"] as const;
+export const OPENCODE_AUTH_PATH = join(homedir(), ".local", "share", "opencode", "auth.json");
+
 export interface OpencodeExecutionInput {
   prompt: string;
   cwd: string;
@@ -26,8 +29,6 @@ export class OpencodeExecutionError extends Error {
     this.code = code;
   }
 }
-
-const OPENCODE_AUTH_PATH = join(homedir(), ".local", "share", "opencode", "auth.json");
 
 export async function hasOpencodeAuth(): Promise<boolean> {
   if (existsSync(OPENCODE_AUTH_PATH)) {

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { Logger } from "pino";
@@ -28,10 +29,10 @@ export class OpencodeExecutionError extends Error {
 
 const OPENCODE_AUTH_PATH = join(homedir(), ".local", "share", "opencode", "auth.json");
 
-export function hasOpencodeAuth(): boolean {
+export async function hasOpencodeAuth(): Promise<boolean> {
   if (existsSync(OPENCODE_AUTH_PATH)) {
     try {
-      const raw = readFileSync(OPENCODE_AUTH_PATH, "utf-8");
+      const raw = await readFile(OPENCODE_AUTH_PATH, "utf-8");
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       if (typeof parsed === "object" && parsed !== null && Object.keys(parsed).length > 0) {
         return true;
@@ -45,7 +46,7 @@ export function hasOpencodeAuth(): boolean {
 }
 
 export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: Logger): Promise<OpencodeExecutionResult> {
-  if (!hasOpencodeAuth() && !(input.env?.DEEPSEEK_API_KEY || process.env.DEEPSEEK_API_KEY)?.trim()) {
+  if (!(await hasOpencodeAuth()) && !(input.env?.DEEPSEEK_API_KEY || process.env.DEEPSEEK_API_KEY)?.trim()) {
     throw new OpencodeExecutionError("NOT_AUTHENTICATED", "Opencode requires an API key. Use `/opencode-auth` to configure keys, or set `DEEPSEEK_API_KEY` on the instance.");
   }
 

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -1,3 +1,6 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import type { Logger } from "pino";
 import { runProviderRequest } from "../utils/runProviderRequest.js";
 
@@ -23,11 +26,29 @@ export class OpencodeExecutionError extends Error {
   }
 }
 
-export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: Logger): Promise<OpencodeExecutionResult> {
-  const apiKey = input.env?.DEEPSEEK_API_KEY || process.env.DEEPSEEK_API_KEY;
-  if (!apiKey?.trim()) {
-    throw new OpencodeExecutionError("NOT_AUTHENTICATED", "Opencode requires `DEEPSEEK_API_KEY` to be set for DeepSeek API access.");
+const OPENCODE_AUTH_PATH = join(homedir(), ".local", "share", "opencode", "auth.json");
+
+export function hasOpencodeAuth(): boolean {
+  if (existsSync(OPENCODE_AUTH_PATH)) {
+    try {
+      const raw = readFileSync(OPENCODE_AUTH_PATH, "utf-8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (typeof parsed === "object" && parsed !== null && Object.keys(parsed).length > 0) {
+        return true;
+      }
+    } catch {
+      // Malformed file — deem it absent
+    }
   }
+
+  return false;
+}
+
+export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: Logger): Promise<OpencodeExecutionResult> {
+  if (!hasOpencodeAuth() && !(input.env?.DEEPSEEK_API_KEY || process.env.DEEPSEEK_API_KEY)?.trim()) {
+    throw new OpencodeExecutionError("NOT_AUTHENTICATED", "Opencode requires an API key. Use `/opencode-auth` to configure keys, or set `DEEPSEEK_API_KEY` on the instance.");
+  }
+
   const text = await runProviderRequest(
     input,
     {
@@ -40,7 +61,7 @@ export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: 
       unavailableCode: "OPENCODE_UNAVAILABLE",
       notAuthenticatedCode: "NOT_AUTHENTICATED",
       authFailurePattern: /not authenticated|API key not found|authentication required|set an Auth method/i,
-      authHint: "Set `DEEPSEEK_API_KEY` to a valid DeepSeek API key.",
+      authHint: "Use `/opencode-auth` to configure API keys.",
       timeoutCode: "TIMEOUT",
       failedCode: "FAILED",
       emptyOutputCode: "EMPTY_OUTPUT",


### PR DESCRIPTION
## Summary

Adds OpenCode CLI as a fourth AI provider in Actuarius, backed by DeepSeek. Uses `opencode run` in non-interactive mode with `DEEPSEEK_API_KEY` env var for auth. Opt-in like codex/gemini (`ENABLE_OPENCODE_EXECUTION=true`).

### Files changed (12 files, +140/-11)

| File | Change |
|------|--------|
| `src/db/types.ts` | Added `"opencode"` to `AiProvider` union |
| `src/config.ts` | Added `ENABLE_OPENCODE_EXECUTION`, `DEEPSEEK_API_KEY` env vars + exports |
| `src/services/opencodeExecutionService.ts` | NEW — wraps `runProviderRequest` with binary `opencode`, args `["run", prompt, "--dangerously-skip-permissions", "--format", "json"]` |
| `src/discord/bot.ts` | Added to `AI_PROVIDER_LABELS`, review candidates, `buildReviewRunners()` skip, `runProviderText()` dispatch, `handleModelSelect()` guard, `describeExecutionError()` |
| `src/discord/commands.ts` | Added `"OpenCode (DeepSeek)"` to `/model-select` provider choices |
| `src/discord/messageTemplates.ts` | Added to help text + v1 notes |
| `src/services/capabilityService.ts` | Added `opencode --version` to startup capability checks |
| `docker/seed-provider-clis.sh` | Added `queue_package_if_missing "opencode" "opencode-ai"` |
| `docker/install-llm-user-instructions.sh` | Added `.opencode/AGENTS.md` to instruction file copy |
| `docker/llm-user-instructions/.opencode/AGENTS.md` | NEW — user-level AGENTS.md for opencode |
| `.env.example` | Documented new env vars |
| `README.md` | Added opencode to CLI list + env config docs |

### Auth

`DEEPSEEK_API_KEY` env var only — opencode auto-detects it from the environment. No `auth.json` seeding needed.

### Usage

- `/model-select provider:opencode` — selects OpenCode as the guild's AI provider
- Supports `--model deepseek/<model>` via the model override in `/model-select`
- Participates in adversarial `/review` as an additional reviewer when enabled
