### PR TITLE
Add enable_opencode_execution terraform variable and env mapping

### DIFF
--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -46,6 +46,7 @@ resource "google_compute_instance" "actuarius" {
     env-ask-concurrency            = var.ask_concurrency
     env-enable-codex-execution     = var.enable_codex_execution
     env-enable-gemini-execution    = var.enable_gemini_execution
+    env-enable-opencode-execution  = var.enable_opencode_execution
     env-gemini-api-key             = var.gemini_api_key
     env-redeploy-script            = file("${path.module}/../scripts/redeploy.sh")
     env-startup-script             = file("${path.module}/startup.sh")

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -87,6 +87,12 @@ variable "enable_gemini_execution" {
   description = "Enable Gemini CLI execution for /ask requests"
 }
 
+variable "enable_opencode_execution" {
+  type        = bool
+  default     = false
+  description = "Enable OpenCode CLI execution for /ask requests"
+}
+
 variable "gemini_api_key" {
   type        = string
   sensitive   = true


### PR DESCRIPTION
## Summary

Adds the `enable_opencode_execution` terraform variable so the VM instance gets `ENABLE_OPENCODE_EXECUTION=true` set in the environment, enabling the OpenCode AI provider that was merged in PR #106.

### Changes

- `infra/variables.tf` — new `enable_opencode_execution` bool variable (default: false)
- `infra/compute.tf` — maps the variable to `env-enable-opencode-execution` metadata entry