### PR TITLE
Pass ENABLE_OPENCODE_EXECUTION to docker container in redeploy.sh

### DIFF
--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -60,6 +60,7 @@ if [ -z "$ASK_CONCURRENCY" ];        then echo "FATAL: env-ask-concurrency is no
 
 ENABLE_CODEX=$(get_meta "env-enable-codex-execution" || true)
 ENABLE_GEMINI=$(get_meta "env-enable-gemini-execution" || true)
+ENABLE_OPENCODE=$(get_meta "env-enable-opencode-execution" || true)
 GEMINI_API_KEY=$(get_meta "env-gemini-api-key" || true)
 
 EXTRA_ARGS=()
@@ -83,6 +84,9 @@ if [ "$ENABLE_CODEX" = "true" ]; then
 fi
 if [ "$ENABLE_GEMINI" = "true" ]; then
   EXTRA_ARGS+=(-e "ENABLE_GEMINI_EXECUTION=true")
+fi
+if [ "$ENABLE_OPENCODE" = "true" ]; then
+  EXTRA_ARGS+=(-e "ENABLE_OPENCODE_EXECUTION=true")
 fi
 if [ -n "$GEMINI_API_KEY" ]; then
   EXTRA_ARGS+=(-e "GEMINI_API_KEY=$GEMINI_API_KEY")


### PR DESCRIPTION
## Summary

The terraform metadata `env-enable-opencode-execution` was added in PR #107, but `redeploy.sh` never reads it or passes it to the docker container. Without this, `ENABLE_OPENCODE_EXECUTION` is never set in the bot environment.

### Change

- `scripts/redeploy.sh` — fetch `env-enable-opencode-execution` from metadata and add `-e ENABLE_OPENCODE_EXECUTION=true` when set