### PR TITLE
fix: add -- separator for opencode split args to prevent flag misinterpretation

### DIFF
--- a/src/utils/runProviderRequest.ts
+++ b/src/utils/runProviderRequest.ts
@@ -45,12 +45,23 @@ export async function runProviderRequest(
   logger: Logger
 ): Promise<string> {
   const prefix = config.prefixArgs ?? [];
-  const promptArgs = config.splitPrompt ? input.prompt.split(/[^\S\r\n]+/).filter(Boolean) : [input.prompt];
-  const args = config.positionalPrompt
-    ? [...prefix, ...promptArgs, ...config.extraArgs]
-    : [...prefix, "-p", input.prompt, ...config.extraArgs];
-  if (input.model) {
-    args.push("--model", input.model);
+  let args: string[];
+  if (config.positionalPrompt) {
+    args = [...prefix, ...config.extraArgs];
+    if (input.model) {
+      args.push("--model", input.model);
+    }
+    if (config.splitPrompt) {
+      const promptArgs = input.prompt.split(/[^\S\r\n]+/).filter(Boolean);
+      args.push("--", ...promptArgs);
+    } else {
+      args.push(input.prompt);
+    }
+  } else {
+    args = [...prefix, "-p", input.prompt, ...config.extraArgs];
+    if (input.model) {
+      args.push("--model", input.model);
+    }
   }
 
   logger.debug({ args, cwd: input.cwd, timeoutMs: input.timeoutMs }, `${config.logLabel} subprocess args`);


### PR DESCRIPTION
## Problem

After the split-prompt fix (PR #111), opencode still fails with exit code 1 when the prompt contains any word starting with `-` (e.g. `--verbose`, `-a`). Opencode arg parser treats those words as unknown flags and prints help + exits.

## Fix

Insert `--` between flags and the split positional prompt args, so nothing after `--` is parsed as a flag:

- **Before**: `opencode run --dangerously-skip-permissions --model deepseek/v4-pro write a --verbose function`
- **After**: `opencode run --dangerously-skip-permissions --model deepseek/v4-pro -- write a --verbose function`

The `--model` flag is pushed before the `--` separator so it still works.