### PR TITLE
fix: pass --dir to opencode and prepend repo context to /ask prompts

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -2309,7 +2309,7 @@ Output the result of the command or the link to the created issue.`;
       stage = "run-ai";
       let effectivePrompt = input.existingWorktreePath
         ? await this.buildThreadPromptWithHistory(channel, input.prompt)
-        : input.prompt;
+        : `Repository: ${input.repo.fullName}\n\n${input.prompt}`;
       if (input.promptTransformer && !input.existingWorktreePath) {
         effectivePrompt = input.promptTransformer(effectivePrompt);
       }

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -2309,7 +2309,8 @@ Output the result of the command or the link to the created issue.`;
       stage = "run-ai";
       let effectivePrompt = input.existingWorktreePath
         ? await this.buildThreadPromptWithHistory(channel, input.prompt)
-        : `Repository: ${input.repo.fullName}\n\n${input.prompt}`;
+        : input.prompt;
+      effectivePrompt = `Repository: ${input.repo.fullName}\n\n${effectivePrompt}`;
       if (input.promptTransformer && !input.existingWorktreePath) {
         effectivePrompt = input.promptTransformer(effectivePrompt);
       }

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -57,6 +57,7 @@ export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: 
       binary: "opencode",
       prefixArgs: ["run"],
       positionalPrompt: true,
+      cwdFlag: "--dir",
       extraArgs: ["--dangerously-skip-permissions"],
       logLabel: "OpenCode",
       makeError: (code, message) => new OpencodeExecutionError(code as OpencodeExecutionError["code"], message),

--- a/src/utils/runProviderRequest.ts
+++ b/src/utils/runProviderRequest.ts
@@ -18,6 +18,13 @@ export interface ProviderRunnerConfig {
   extraArgs: string[];
   /** If true, pass the prompt as a positional arg instead of `-p <prompt>`. */
   positionalPrompt?: boolean;
+  /**
+   * If set, inject `[cwdFlag, input.cwd]` immediately after prefixArgs.
+   * Use for CLIs that don't honor the process cwd as their project root —
+   * notably opencode, which resolves project context via `.git` and gets
+   * confused by git worktrees.
+   */
+  cwdFlag?: string;
   /** Human-readable label used in log messages, e.g. "Codex". */
   logLabel: string;
   makeError: (code: string, message: string) => Error;
@@ -43,9 +50,10 @@ export async function runProviderRequest(
   logger: Logger
 ): Promise<string> {
   const prefix = config.prefixArgs ?? [];
+  const cwdArgs = config.cwdFlag ? [config.cwdFlag, input.cwd] : [];
   const args = config.positionalPrompt
-    ? [...prefix, input.prompt, ...config.extraArgs]
-    : [...prefix, "-p", input.prompt, ...config.extraArgs];
+    ? [...prefix, ...cwdArgs, input.prompt, ...config.extraArgs]
+    : [...prefix, ...cwdArgs, "-p", input.prompt, ...config.extraArgs];
   if (input.model) {
     args.push("--model", input.model);
   }


### PR DESCRIPTION
## Problem

OpenCode operated on the wrong repository entirely. Spawned with `cwd = /data/repos/.worktrees/digitumdei/shotquill/671`, it ended up committing to `DigitumDei/Actuarius`.

## Root Cause

Two issues:

1. **`--dir` not passed**: opencode resolves its project root by inspecting `.git`, not by honoring process `cwd`. In a git worktree, `.git` is a FILE containing `gitdir: <main>/.git/worktrees/<id>` — a pointer back to the main repo's gitdir. opencode follows that pointer to the base checkout, completely bypassing the worktree.

2. **No repo context in prompt**: Even with the correct cwd, the LLM had no explicit repo identifier in the prompt text.

## Fix

### 1. `src/utils/runProviderRequest.ts` — `cwdFlag` support
Added optional `cwdFlag?: string` to `ProviderRunnerConfig`. When set, injects `[cwdFlag, input.cwd]` after prefixArgs (before the prompt). Framework-level change usable by any provider.

### 2. `src/services/opencodeExecutionService.ts` — set `cwdFlag: "--dir"`
Result: `opencode run --dir <worktree> <prompt> --dangerously-skip-permissions`

### 3. `src/discord/bot.ts` — prepend repo name (belt-and-braces)
Prepends `Repository: <owner/repo>` to new-thread prompts so the LLM has explicit context.

## Testing

- `npm run check` — passes
- `botCommands.test.ts` — 30/30 passed
- Full suite: pre-existing failures only (Windows platform, bash dependency)
