### PR TITLE
infra: wire MEMPALACE_ENABLED through Terraform

### DIFF
--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -47,6 +47,7 @@ resource "google_compute_instance" "actuarius" {
     env-enable-codex-execution     = var.enable_codex_execution
     env-enable-gemini-execution    = var.enable_gemini_execution
     env-enable-opencode-execution  = var.enable_opencode_execution
+    env-enable-mempalace           = var.enable_mempalace
     env-gemini-api-key             = var.gemini_api_key
     env-redeploy-script            = file("${path.module}/../scripts/redeploy.sh")
     env-startup-script             = file("${path.module}/startup.sh")

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -29,3 +29,6 @@ claude_oauth_token = "replace_me"
 enable_codex_execution  = true
 enable_gemini_execution = true
 gemini_api_key          = "replace_me"
+
+# Enable MemPalace persistent cross-request memory
+enable_mempalace = true

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -93,6 +93,12 @@ variable "enable_opencode_execution" {
   description = "Enable OpenCode CLI execution for /ask requests"
 }
 
+variable "enable_mempalace" {
+  type        = bool
+  default     = false
+  description = "Enable MemPalace persistent cross-request memory (MEMPALACE_ENABLED)"
+}
+
 variable "gemini_api_key" {
   type        = string
   sensitive   = true

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -61,6 +61,7 @@ if [ -z "$ASK_CONCURRENCY" ];        then echo "FATAL: env-ask-concurrency is no
 ENABLE_CODEX=$(get_meta "env-enable-codex-execution" || true)
 ENABLE_GEMINI=$(get_meta "env-enable-gemini-execution" || true)
 ENABLE_OPENCODE=$(get_meta "env-enable-opencode-execution" || true)
+ENABLE_MEMPALACE=$(get_meta "env-enable-mempalace" || true)
 GEMINI_API_KEY=$(get_meta "env-gemini-api-key" || true)
 
 EXTRA_ARGS=()
@@ -87,6 +88,9 @@ if [ "$ENABLE_GEMINI" = "true" ]; then
 fi
 if [ "$ENABLE_OPENCODE" = "true" ]; then
   EXTRA_ARGS+=(-e "ENABLE_OPENCODE_EXECUTION=true")
+fi
+if [ "$ENABLE_MEMPALACE" = "true" ]; then
+  EXTRA_ARGS+=(-e "MEMPALACE_ENABLED=true")
 fi
 if [ -n "$GEMINI_API_KEY" ]; then
   EXTRA_ARGS+=(-e "GEMINI_API_KEY=$GEMINI_API_KEY")


### PR DESCRIPTION
## Context

The MemPalace integration (#103, merged via #117) added the `MEMPALACE_ENABLED` env var, but the Terraform-managed GCP deployment had no way to set it. The flag only existed in local `.env`, so production could not actually turn on persistent cross-request memory. This wires the toggle through Terraform so prod can enable it.

## Changes

Threads a new `enable_mempalace` bool through the same path as the existing provider toggles (`enable_opencode_execution` etc.):

- **`infra/variables.tf`** — new `enable_mempalace` bool (default `false`)
- **`infra/compute.tf`** — new `env-enable-mempalace` instance-metadata entry
- **`scripts/redeploy.sh`** — reads the metadata value and adds `-e MEMPALACE_ENABLED=true` to the container when set
- **`infra/terraform.tfvars.example`** — documents the new var

`MEMPALACE_PALACE_PATH` and `MEMPALACE_BINARY_PATH` keep their `config.ts` defaults (`/data/mempalace/palace` on the persisted disk, `/usr/local/bin/mempalace-mcp` baked into the image), so no extra vars are needed.

## Verification

- `terraform validate` ✅
- `terraform plan` ✅ — **`0 to add, 1 to change, 0 to destroy`** (in-place VM metadata update, no rebuild, persistent disk untouched)

## Deploy note

⚠️ GCP applies metadata changes live without rebooting, so `MEMPALACE_ENABLED=true` only reaches the container when `redeploy.sh` re-runs. After `terraform apply`, reboot the VM (or run the redeploy script) to restart the container with the new env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)