### PR TITLE
infra: move swap file from data disk to stateful partition

### DIFF
--- a/infra/startup.sh
+++ b/infra/startup.sh
@@ -26,10 +26,19 @@ touch "$DATA_MNT/app.db"
 chown 1001:1001 "$DATA_MNT"
 find "$DATA_MNT" -maxdepth 1 -not -name .swapfile -not -path "$DATA_MNT" -exec chown -R 1001:1001 {} +
 
-# --- Swap file on data disk (safety margin for Claude CLI subprocesses) ---
-SWAP="$DATA_MNT/.swapfile"
+# --- Swap file (safety margin for Claude CLI subprocesses) ---
+# Lives on the stateful partition, NOT the data disk: the data disk holds the
+# palace/repos/worktrees and is space-constrained — a full /data wedges the bot,
+# whereas the stateful partition (shared with /var/lib/docker) has headroom.
+SWAP="/mnt/stateful_partition/swapfile"
+# Migrate off the old data-disk location if present, reclaiming ~1 GB on /data.
+OLD_SWAP="$DATA_MNT/.swapfile"
+if [ -f "$OLD_SWAP" ]; then
+  swapoff "$OLD_SWAP" 2>/dev/null || true
+  rm -f "$OLD_SWAP"
+fi
 if [ ! -f "$SWAP" ]; then
-  fallocate -l 1G "$SWAP"
+  fallocate -l 1536M "$SWAP"
   chmod 600 "$SWAP"
   mkswap "$SWAP"
 fi


### PR DESCRIPTION
## What

Move the VM swapfile from the **data disk** (`/mnt/disks/data`) to the **stateful partition** (`/mnt/stateful_partition`) in `infra/startup.sh`, and bump it 1 GB → 1.5 GB.

## Why

`startup.sh` was creating a 1 GB swapfile on the data disk — the same `/dev/sdb` volume that holds the MemPalace palace, cloned repos, and per-request `/ask` worktrees. On the live e2-micro (free tier, 1 GB RAM) that disk was observed at **87% full, ~1.3 GB free**, with the swapfile itself consuming ~1 GB of it.

That's the wrong place for swap:
- A full `/data` **wedges the bot** — npm `ENOSPC`/`ENOTEMPTY` (see #119), failed worktree creation — and risks data loss.
- The stateful partition has **4.4 GB free** and only shares space with `/var/lib/docker`, which is recoverable (re-pull the image) rather than precious.

The box is genuinely memory-pressured (observed ~224 MB already paged out), so swap stays — it just moves somewhere safe and gets a little bigger.

## Change

- `SWAP` → `/mnt/stateful_partition/swapfile`, size `1536M`.
- On boot, migrate off the old data-disk location (`swapoff` + `rm`), reclaiming ~1 GB on `/data`.
- The chown pass already excludes `.swapfile`, so no change needed there.

## Deploy notes (COS specifics)

`startup.sh` is delivered via instance **metadata** (`compute.tf` `env-startup-script`) and only runs **on boot**. So after merge:

1. `terraform apply` — pushes the new script into metadata (in-place, no VM recreation).
2. Trigger it without a full reboot:
   ```bash
   curl -sf -H "Metadata-Flavor: Google" \
     "http://metadata.google.internal/computeMetadata/v1/instance/attributes/env-startup-script" \
     > /var/startup-inner.sh && sudo bash /var/startup-inner.sh
   ```
3. **Heads-up:** if a 2 GB swapfile was hand-created at `/mnt/stateful_partition/swapfile` during testing, the `[ ! -f ]` guard will skip recreation (you'd keep 2 GB, not 1.5 GB). Clear it first to land exactly 1.5 GB:
   ```bash
   sudo swapoff /mnt/stateful_partition/swapfile && sudo rm /mnt/stateful_partition/swapfile
   ```
4. Verify: `sudo swapon --show` (1.5 GB on stateful) and `df -h /mnt/disks/data` (~1 GB reclaimed).

⚠️ Avoid a hard reboot while an autonomous `/ask` is running — it kills the in-flight request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
