### PR TITLE
test: skip Linux-container-only tests on Windows instead of failing

### DIFF
--- a/tests/installService.test.ts
+++ b/tests/installService.test.ts
@@ -12,6 +12,13 @@ vi.mock("../src/utils/spawnCollect.js");
 const { spawnCollect } = await import("../src/utils/spawnCollect.js");
 const mockSpawnCollect = vi.mocked(spawnCollect);
 
+// The InstallService targets the Linux container: it builds POSIX install paths
+// (path.join → "/data/..."), inspects process.getuid, and shells out to sudo/apt.
+// On Windows path.join yields "\data\..." and process.getuid is undefined, so these
+// assertions can only hold on POSIX. They run in CI (Linux); skipped on win32 so a
+// local `npm test` reports them as skipped rather than spuriously failing.
+const itLinuxOnly = it.skipIf(process.platform === "win32");
+
 function createInMemoryDb(): AppDatabase {
   const db = new AppDatabase(":memory:");
   db.runMigrations();
@@ -77,7 +84,7 @@ describe("InstallService", () => {
     writeFileSync(filePath, content, "utf8");
   }
 
-  it("creates approved install requests in scoped directories", () => {
+  itLinuxOnly("creates approved install requests in scoped directories", () => {
     const request = db.createRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -172,7 +179,7 @@ describe("InstallService", () => {
     expect(execution.env.PATH).toContain("/data/tool-installs/request/thread-1/rustup-default-stable/bin");
   });
 
-  it("updates request lifecycle states while running a request-scoped install", async () => {
+  itLinuxOnly("updates request lifecycle states while running a request-scoped install", async () => {
     const request = db.createRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -207,7 +214,7 @@ describe("InstallService", () => {
     );
   });
 
-  it("bootstraps rustup inside the scoped install root instead of requiring a system rustup", async () => {
+  itLinuxOnly("bootstraps rustup inside the scoped install root instead of requiring a system rustup", async () => {
     const install = db.createInstallRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -327,7 +334,7 @@ describe("InstallService", () => {
     ).toThrowError(expect.objectContaining({ code: "UNKNOWN_PACKAGE" }));
   });
 
-  it("accepts apt package requests and stores them in a shared system install root", () => {
+  itLinuxOnly("accepts apt package requests and stores them in a shared system install root", () => {
     const install = service.createApprovedInstallRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -479,7 +486,7 @@ describe("InstallService", () => {
     expect(install.package_version).toBe("34");
   });
 
-  it("passes prior repo-scope install env into later install steps", async () => {
+  itLinuxOnly("passes prior repo-scope install env into later install steps", async () => {
     const priorInstall = db.createInstallRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -555,7 +562,7 @@ describe("InstallService", () => {
     ).toThrowError(expect.objectContaining({ code: "CONFIG_INVALID" }));
   });
 
-  it("fails apt installs early when the process is not running as root", async () => {
+  itLinuxOnly("fails apt installs early when the process is not running as root", async () => {
     const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1001);
     const install = db.createInstallRequest({
       guildId: "guild-1",
@@ -577,7 +584,7 @@ describe("InstallService", () => {
     getuidSpy.mockRestore();
   });
 
-  it("uses the configured apt helper via sudo when the process is not running as root", async () => {
+  itLinuxOnly("uses the configured apt helper via sudo when the process is not running as root", async () => {
     const helperPath = join(tmpdir(), "actuarius-apt-install-test-helper");
     writeFileSync(helperPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
     const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1001);

--- a/tests/installService.test.ts
+++ b/tests/installService.test.ts
@@ -15,9 +15,10 @@ const mockSpawnCollect = vi.mocked(spawnCollect);
 // The InstallService targets the Linux container: it builds POSIX install paths
 // (path.join → "/data/..."), inspects process.getuid, and shells out to sudo/apt.
 // On Windows path.join yields "\data\..." and process.getuid is undefined, so these
-// assertions can only hold on POSIX. They run in CI (Linux); skipped on win32 so a
-// local `npm test` reports them as skipped rather than spuriously failing.
-const itLinuxOnly = it.skipIf(process.platform === "win32");
+// assertions can only hold on POSIX. They still run on macOS (also POSIX) and in CI
+// (Linux); only win32 is skipped, so a local `npm test` on Windows reports them as
+// skipped rather than spuriously failing.
+const itPosixOnly = it.skipIf(process.platform === "win32");
 
 function createInMemoryDb(): AppDatabase {
   const db = new AppDatabase(":memory:");
@@ -84,7 +85,7 @@ describe("InstallService", () => {
     writeFileSync(filePath, content, "utf8");
   }
 
-  itLinuxOnly("creates approved install requests in scoped directories", () => {
+  itPosixOnly("creates approved install requests in scoped directories", () => {
     const request = db.createRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -179,7 +180,7 @@ describe("InstallService", () => {
     expect(execution.env.PATH).toContain("/data/tool-installs/request/thread-1/rustup-default-stable/bin");
   });
 
-  itLinuxOnly("updates request lifecycle states while running a request-scoped install", async () => {
+  itPosixOnly("updates request lifecycle states while running a request-scoped install", async () => {
     const request = db.createRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -214,7 +215,7 @@ describe("InstallService", () => {
     );
   });
 
-  itLinuxOnly("bootstraps rustup inside the scoped install root instead of requiring a system rustup", async () => {
+  itPosixOnly("bootstraps rustup inside the scoped install root instead of requiring a system rustup", async () => {
     const install = db.createInstallRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -334,7 +335,7 @@ describe("InstallService", () => {
     ).toThrowError(expect.objectContaining({ code: "UNKNOWN_PACKAGE" }));
   });
 
-  itLinuxOnly("accepts apt package requests and stores them in a shared system install root", () => {
+  itPosixOnly("accepts apt package requests and stores them in a shared system install root", () => {
     const install = service.createApprovedInstallRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -486,7 +487,7 @@ describe("InstallService", () => {
     expect(install.package_version).toBe("34");
   });
 
-  itLinuxOnly("passes prior repo-scope install env into later install steps", async () => {
+  itPosixOnly("passes prior repo-scope install env into later install steps", async () => {
     const priorInstall = db.createInstallRequest({
       guildId: "guild-1",
       repoId: 1,
@@ -562,7 +563,7 @@ describe("InstallService", () => {
     ).toThrowError(expect.objectContaining({ code: "CONFIG_INVALID" }));
   });
 
-  itLinuxOnly("fails apt installs early when the process is not running as root", async () => {
+  itPosixOnly("fails apt installs early when the process is not running as root", async () => {
     const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1001);
     const install = db.createInstallRequest({
       guildId: "guild-1",
@@ -584,7 +585,7 @@ describe("InstallService", () => {
     getuidSpy.mockRestore();
   });
 
-  itLinuxOnly("uses the configured apt helper via sudo when the process is not running as root", async () => {
+  itPosixOnly("uses the configured apt helper via sudo when the process is not running as root", async () => {
     const helperPath = join(tmpdir(), "actuarius-apt-install-test-helper");
     writeFileSync(helperPath, "#!/usr/bin/env bash\nexit 0\n", { encoding: "utf8", mode: 0o755 });
     const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1001);

--- a/tests/seedProviderClis.test.ts
+++ b/tests/seedProviderClis.test.ts
@@ -171,7 +171,10 @@ describe("seed-provider-clis.sh", () => {
     expect(result.stderr).toContain("@openai/codex");
   });
 
-  it("continues container startup when provider seeding fails", () => {
+  // Runs the real container entrypoint via `sh`, which invokes Linux-only commands
+  // (returns 127 "command not found" on a Windows shell). Runs in CI (Linux);
+  // skipped on win32 so local `npm test` reports it skipped, not failed.
+  it.skipIf(process.platform === "win32")("continues container startup when provider seeding fails", () => {
     const result = runEntrypointWithFailingSeed();
 
     expect(result.status).toBe(0);


### PR DESCRIPTION
## What

Gate 8 tests that only make sense in the Linux runtime with `it.skipIf(process.platform === "win32")` so they're reported as **skipped** (not **failed**) on Windows dev machines. They continue to run in CI (Linux).

## Why

Running `npm test` on a Windows dev box reported 8 failures that are environmental, not real bugs — masking genuine regressions and eroding trust in the local suite. The causes (initially mis-attributed to a `DOCKER_HOST` env leak — that was a red herring in vitest's diff output):

- **installService (7 tests)** — the service builds POSIX container paths (`path.join` → `/data/...` on Linux, but `\data\...` on Windows) and inspects `process.getuid` (undefined on Windows) for the run-as-non-root sudo/apt paths. The path-string and `getuid` assertions can only hold on POSIX.
- **seedProviderClis (1 test)** — `continues container startup when provider seeding fails` runs the real container entrypoint via `sh`, which invokes Linux-only commands and exits 127 ("command not found") under a Windows shell. (The other 3 seed tests run the simpler seed script directly and still pass on Windows with git-bash, so they're left untouched.)

## How

- `tests/installService.test.ts`: added a shared `itLinuxOnly = it.skipIf(process.platform === "win32")` helper (with a comment explaining the POSIX/getuid rationale) and applied it to the 7 affected tests.
- `tests/seedProviderClis.test.ts`: gated the single entrypoint test with `it.skipIf(process.platform === "win32")`.

**No product code changed.**

## Verification

- `npm run check` — clean.
- `npm test` on Windows — **156 passed / 8 skipped / 0 failed** (was 156 passed / 8 failed).
- On Linux/CI the gate is inert, so all 164 tests still execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
