### PR TITLE
fix: migrate guild_model_config.model from NOT NULL to nullable

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -168,25 +168,40 @@ export class AppDatabase {
       notnull: number;
     }>;
     if (guildModelConfigModelInfo.find((c) => c.name === "model")?.notnull === 1) {
-      this.db.exec(`
-        CREATE TABLE guild_model_config_v2 (
-          guild_id TEXT PRIMARY KEY,
-          provider TEXT NOT NULL,
-          model TEXT,
-          planner_provider TEXT,
-          planner_model TEXT,
-          implementer_provider TEXT,
-          implementer_model TEXT,
-          updated_by_user_id TEXT NOT NULL,
-          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-          FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
-        );
-        INSERT INTO guild_model_config_v2 (guild_id, provider, model, updated_by_user_id, updated_at)
-          SELECT guild_id, provider, NULLIF(model, ''), updated_by_user_id, updated_at
-          FROM guild_model_config;
-        DROP TABLE guild_model_config;
-        ALTER TABLE guild_model_config_v2 RENAME TO guild_model_config;
-      `);
+      // PR #120 may have already added the planner/implementer columns via ALTER TABLE
+      // and guilds that had a default model could have planner data — preserve it.
+      const hasPlannerColumns = guildModelConfigModelInfo.some((c) => c.name === "planner_provider");
+      const extraCols = hasPlannerColumns
+        ? ["planner_provider", "planner_model", "implementer_provider", "implementer_model"]
+        : [];
+      const insertCols = ["guild_id", "provider", "model", "updated_by_user_id", "updated_at", ...extraCols].join(", ");
+      const selectCols = ["guild_id", "provider", "NULLIF(model, '')", "updated_by_user_id", "updated_at", ...extraCols].join(", ");
+
+      this.db.exec("BEGIN");
+      try {
+        this.db.exec(`
+          CREATE TABLE guild_model_config_v2 (
+            guild_id TEXT PRIMARY KEY,
+            provider TEXT NOT NULL,
+            model TEXT,
+            planner_provider TEXT,
+            planner_model TEXT,
+            implementer_provider TEXT,
+            implementer_model TEXT,
+            updated_by_user_id TEXT NOT NULL,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
+          );
+          INSERT INTO guild_model_config_v2 (${insertCols})
+            SELECT ${selectCols} FROM guild_model_config;
+          DROP TABLE guild_model_config;
+          ALTER TABLE guild_model_config_v2 RENAME TO guild_model_config;
+        `);
+        this.db.exec("COMMIT");
+      } catch (error) {
+        this.db.exec("ROLLBACK");
+        throw error;
+      }
     }
 
     const guildModelConfigColumns = new Map([

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -160,6 +160,35 @@ export class AppDatabase {
       );
     `);
 
+    // Migrate: the original schema had `model TEXT NOT NULL`; it must be nullable so
+    // setGuildRoleModelConfig can insert a placeholder row without a default model.
+    // SQLite cannot drop a NOT NULL constraint via ALTER TABLE, so recreate the table.
+    const guildModelConfigModelInfo = this.db.prepare("PRAGMA table_info(guild_model_config)").all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    if (guildModelConfigModelInfo.find((c) => c.name === "model")?.notnull === 1) {
+      this.db.exec(`
+        CREATE TABLE guild_model_config_v2 (
+          guild_id TEXT PRIMARY KEY,
+          provider TEXT NOT NULL,
+          model TEXT,
+          planner_provider TEXT,
+          planner_model TEXT,
+          implementer_provider TEXT,
+          implementer_model TEXT,
+          updated_by_user_id TEXT NOT NULL,
+          updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          FOREIGN KEY (guild_id) REFERENCES guilds(id) ON DELETE CASCADE
+        );
+        INSERT INTO guild_model_config_v2 (guild_id, provider, model, updated_by_user_id, updated_at)
+          SELECT guild_id, provider, NULLIF(model, ''), updated_by_user_id, updated_at
+          FROM guild_model_config;
+        DROP TABLE guild_model_config;
+        ALTER TABLE guild_model_config_v2 RENAME TO guild_model_config;
+      `);
+    }
+
     const guildModelConfigColumns = new Map([
       ["planner_provider", "TEXT"],
       ["planner_model", "TEXT"],


### PR DESCRIPTION
## Root cause

The original `guild_model_config` schema (`dba3085`) defined `model TEXT NOT NULL`. PR #120 added `setGuildRoleModelConfig`, which INSERTs `model = NULL` as a placeholder when creating a new row for a guild that has never set a default model. On any instance where the database pre-dates PR #120, the `CREATE TABLE IF NOT EXISTS` was a no-op (table already existed), so the `model NOT NULL` constraint was never dropped — only the new planner/implementer columns were added via `ALTER TABLE`. Calling `/model` with `role: planner` or `role: implementer` on such an instance hit `SQLITE_CONSTRAINT_NOTNULL` (errcode 1299).

## Fix

Adds a one-time migration in `initialize()` that checks whether `model` still carries a `NOT NULL` constraint via `PRAGMA table_info`. If so, it recreates the table with the correct nullable schema and copies all existing rows (`NULLIF(model, '')` normalises any empty-string values to NULL). After the recreation the existing `ALTER TABLE` column migrations for `planner_provider` / `planner_model` etc. are a no-op (columns already present), so there's no double-migration risk.

## Test plan

- [ ] All 12 existing `guildModelConfig.test.ts` tests pass
- [ ] `npm run check` passes
- [ ] Deploy to the container, restart, then set `/model provider:gemini role:planner` — should succeed instead of logging `ERR_SQLITE_ERROR` constraint failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)