### PR TITLE
fix: iterative plan robustness (auto-commit + preserve worktree on failure)

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -3031,7 +3031,9 @@ Output the result of the command or the link to the created issue.`;
       if (threadChannel && threadChannel.isThread()) {
         await threadChannel.send(`**Plan request failed during ${stage}**\n\n${clipForDiscord(message, DISCORD_MESSAGE_LIMIT - 60)}`);
       }
-      await cleanupFailedWorktree();
+      if (stage !== "iterative-loop") {
+        await cleanupFailedWorktree();
+      }
       this.logger.error({ error, requestId: input.requestId, durationMs: Date.now() - startedAt, stage }, "Plan request failed");
     }
   }

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -40,6 +40,7 @@ import {
 } from "../services/githubService.js";
 import {
   GitWorkspaceError,
+  autoCommitAll,
   cleanupDeletedRemoteBranches,
   detectDefaultBranch,
   ensureRepoCheckedOutToMaster,
@@ -2927,7 +2928,8 @@ Output the result of the command or the link to the created issue.`;
           env,
           getHeadSha,
           getDiffSinceRef,
-          hasUncommittedChanges
+          hasUncommittedChanges,
+          autoCommitAll
         });
 
         this.db.updateRequestStatus(input.requestId, "succeeded");

--- a/src/services/gitWorkspaceService.ts
+++ b/src/services/gitWorkspaceService.ts
@@ -422,6 +422,11 @@ export async function hasUncommittedChanges(worktreePath: string): Promise<boole
   return !(await isWorktreeClean(worktreePath));
 }
 
+export async function autoCommitAll(worktreePath: string, message: string): Promise<void> {
+  await runGitWithOutput(["add", "-A"], { cwd: worktreePath });
+  await runGitWithOutput(["commit", "-m", message], { cwd: worktreePath });
+}
+
 export async function detectDefaultBranch(repoPath: string): Promise<{ branchName: string; remoteRef: string }> {
   const candidates = ["main", "master"] as const;
 

--- a/src/services/iterativeTaskLoopService.ts
+++ b/src/services/iterativeTaskLoopService.ts
@@ -121,7 +121,7 @@ export async function runIterativeTaskLoop(input: IterativeTaskLoopInput): Promi
       });
 
       if (await input.hasUncommittedChanges(worktreePath)) {
-        const autoMsg = `task ${taskIndex}/${taskCount}: ${task.title} (auto-committed)`;
+        const autoMsg = `task ${taskIndex}/${taskCount}: ${taskTitle} (auto-committed)`;
         await input.autoCommitAll(worktreePath, autoMsg);
         await threadChannel.send(
           `Task ${taskIndex}/${taskCount}: ${taskTitle} - implementer left uncommitted changes; auto-committed.`

--- a/src/services/iterativeTaskLoopService.ts
+++ b/src/services/iterativeTaskLoopService.ts
@@ -39,6 +39,7 @@ export interface IterativeTaskLoopInput {
   getHeadSha: (repoPath: string, ref?: string) => Promise<string>;
   getDiffSinceRef: (repoPath: string, baseRef: string) => Promise<string>;
   hasUncommittedChanges: (repoPath: string) => Promise<boolean>;
+  autoCommitAll: (repoPath: string, message: string) => Promise<void>;
 }
 
 const MAX_TWEAKS_PER_TASK = 3;
@@ -120,7 +121,11 @@ export async function runIterativeTaskLoop(input: IterativeTaskLoopInput): Promi
       });
 
       if (await input.hasUncommittedChanges(worktreePath)) {
-        throw new Error(`Task ${taskIndex}/${taskCount} left uncommitted changes in the worktree. Commit or discard task changes before continuing.`);
+        const autoMsg = `task ${taskIndex}/${taskCount}: ${task.title} (auto-committed)`;
+        await input.autoCommitAll(worktreePath, autoMsg);
+        await threadChannel.send(
+          `Task ${taskIndex}/${taskCount}: ${taskTitle} - implementer left uncommitted changes; auto-committed.`
+        );
       }
 
       diff = await input.getDiffSinceRef(worktreePath, preTaskSha);

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -1861,6 +1861,53 @@ describe("ActuariusBot plan runner", () => {
     expect(send).toHaveBeenCalledWith(expect.stringContaining("Plan request failed during planning"));
   });
 
+  it("preserves worktree when iterative loop fails so /revise can continue", async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const updateRequestStatus = vi.fn();
+    const updateRequestWorkspace = vi.fn();
+    const bot = createBot({ updateRequestStatus, updateRequestWorkspace });
+
+    vi.mocked(ensureRepoCheckedOutToMaster).mockResolvedValue({ localPath: "/tmp/repo" });
+    vi.mocked(createRequestWorktree).mockResolvedValue({
+      path: "/tmp/worktree-plan",
+      branchName: "ask/94-123"
+    });
+    vi.mocked(runIterativeTaskLoop).mockRejectedValue(new Error("task 2 failed"));
+    vi.mocked(deleteRequestBranch).mockResolvedValue(undefined);
+    (bot as any).client.channels.fetch = vi.fn().mockResolvedValue({
+      isThread: () => true,
+      send
+    });
+    (bot as any).installService.buildExecutionEnvironment = vi.fn().mockReturnValue({
+      packages: [],
+      env: {}
+    });
+    (bot as any).runProviderText = vi.fn().mockResolvedValueOnce(JSON.stringify({
+      overview: "Test plan",
+      tasks: [
+        { title: "Task 1", description: "First task" },
+        { title: "Task 2", description: "Second task" }
+      ]
+    }));
+
+    await (bot as any).runPlanRequest({
+      requestId: 94,
+      threadId: "thread-1",
+      repoId: 5,
+      repo: { owner: "octocat", repo: "hello-world", fullName: "octocat/hello-world" },
+      prompt: "Do iterative thing",
+      planner: { provider: "claude" },
+      implementer: { provider: "claude" },
+      iterative: true
+    });
+
+    expect(updateRequestStatus).toHaveBeenCalledWith(94, "failed");
+    expect(deleteRequestBranch).not.toHaveBeenCalled();
+    expect(updateRequestWorkspace).toHaveBeenCalledTimes(1);
+    expect(updateRequestWorkspace).toHaveBeenCalledWith(94, "/tmp/worktree-plan", "ask/94-123");
+    expect(send).toHaveBeenCalledWith(expect.stringContaining("Plan request failed during iterative-loop"));
+  });
+
   it("iterative false uses existing single-shot implementation behavior", async () => {
     vi.mocked(ensureRepoCheckedOutToMaster).mockResolvedValue({ localPath: "/tmp/repo" });
     vi.mocked(createRequestWorktree).mockResolvedValue({

--- a/tests/iterativeTaskLoopService.test.ts
+++ b/tests/iterativeTaskLoopService.test.ts
@@ -5,6 +5,7 @@ const mockRunProviderText = vi.fn();
 const mockGetHeadSha = vi.fn();
 const mockGetDiffSinceRef = vi.fn();
 const mockHasUncommittedChanges = vi.fn();
+const mockAutoCommitAll = vi.fn();
 const mockSend = vi.fn().mockResolvedValue(undefined);
 
 const defaultInput: IterativeTaskLoopInput = {
@@ -26,7 +27,8 @@ const defaultInput: IterativeTaskLoopInput = {
   env: undefined,
   getHeadSha: mockGetHeadSha,
   getDiffSinceRef: mockGetDiffSinceRef,
-  hasUncommittedChanges: mockHasUncommittedChanges
+  hasUncommittedChanges: mockHasUncommittedChanges,
+  autoCommitAll: mockAutoCommitAll
 };
 
 const { runIterativeTaskLoop } = await import("../src/services/iterativeTaskLoopService.js");
@@ -37,6 +39,7 @@ describe("runIterativeTaskLoop", () => {
     mockGetHeadSha.mockResolvedValue("abc123");
     mockGetDiffSinceRef.mockResolvedValue("diff --git a/src/index.ts b/src/index.ts\n+change");
     mockHasUncommittedChanges.mockResolvedValue(false);
+    mockAutoCommitAll.mockResolvedValue(undefined);
   });
 
   it("runs each task through implementer then verifier", async () => {
@@ -262,35 +265,43 @@ describe("runIterativeTaskLoop", () => {
     expect(implementerPrompt).toContain("The worktree must be clean when you respond");
   });
 
-  it("stops before verification when an implementer leaves uncommitted changes", async () => {
-    mockRunProviderText.mockResolvedValueOnce("impl 1");
+  it("auto-commits and notifies thread when implementer leaves uncommitted changes", async () => {
+    mockRunProviderText
+      .mockResolvedValueOnce("impl 1")
+      .mockResolvedValueOnce("APPROVED");
     mockHasUncommittedChanges.mockResolvedValueOnce(true);
 
-    await expect(runIterativeTaskLoop({
+    const result = await runIterativeTaskLoop({
       ...defaultInput,
       tasks: [{ title: "Task 1", description: "First task" }]
-    })).rejects.toThrow("left uncommitted changes");
+    });
 
-    expect(mockHasUncommittedChanges).toHaveBeenCalledWith("/tmp/worktree");
-    expect(mockGetDiffSinceRef).not.toHaveBeenCalled();
-    expect(mockRunProviderText).toHaveBeenCalledTimes(1);
+    expect(mockAutoCommitAll).toHaveBeenCalledWith("/tmp/worktree", "task 1/1: Task 1 (auto-committed)");
+    expect(mockSend).toHaveBeenCalledWith(expect.stringContaining("auto-committed"));
+    expect(result.taskResults).toHaveLength(1);
+    expect(result.taskResults[0]!.approved).toBe(true);
   });
 
-  it("does not allow task 2 to inherit task 1 uncommitted changes", async () => {
+  it("auto-commits per-task and continues when task 2 also leaves uncommitted changes", async () => {
     mockRunProviderText
       .mockResolvedValueOnce("impl 1")
       .mockResolvedValueOnce("APPROVED")
-      .mockResolvedValueOnce("impl 2");
+      .mockResolvedValueOnce("impl 2")
+      .mockResolvedValueOnce("APPROVED");
     mockHasUncommittedChanges
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(true);
-    mockGetDiffSinceRef.mockResolvedValueOnce("task 1 diff");
+    mockGetDiffSinceRef
+      .mockResolvedValueOnce("task 1 diff")
+      .mockResolvedValueOnce("task 2 diff");
 
-    await expect(runIterativeTaskLoop(defaultInput)).rejects.toThrow("Task 2/2 left uncommitted changes");
+    const result = await runIterativeTaskLoop(defaultInput);
 
-    expect(mockGetDiffSinceRef).toHaveBeenCalledTimes(1);
-    expect(mockGetDiffSinceRef).toHaveBeenCalledWith("/tmp/worktree", "abc123");
-    expect(mockRunProviderText).toHaveBeenCalledTimes(3);
+    expect(mockAutoCommitAll).toHaveBeenCalledTimes(1);
+    expect(mockAutoCommitAll).toHaveBeenCalledWith("/tmp/worktree", "task 2/2: Task 2 (auto-committed)");
+    expect(result.taskResults).toHaveLength(2);
+    expect(result.taskResults[0]!.approved).toBe(true);
+    expect(result.taskResults[1]!.approved).toBe(true);
   });
 
   it("preserves blank-line separators in implementer prompts", async () => {


### PR DESCRIPTION
## Summary

Two bugs in the iterative `/plan` loop, both causing `/revise` to fail after a mid-run error.

### Bug 1 — Hard fail on uncommitted changes (fixes #134)

The loop threw a fatal error when the implementer left uncommitted changes, killing the entire run and discarding all prior task work.

**Fix:** Replace the throw with `git add -A && git commit` (auto-commit), post a thread notice, and continue to planner verification.

### Bug 2 — Worktree deleted on iterative loop failure (fixes #136)

On any plan failure, `cleanupFailedWorktree` deleted the branch and cleared `worktree_path`/`branch_name` in the DB. `/revise` (and `/review`) then returned "This thread does not have a tracked request branch."

**Fix:** Skip `cleanupFailedWorktree` when `stage === "iterative-loop"`. The request is still marked `failed`, but the worktree stays attached so `/revise` can continue from the last committed task.

## Test plan

- [x] `npm run check` passes
- [x] `npx vitest run tests/iterativeTaskLoopService.test.ts` — 24/24 (replaced 2 stale throw tests; added auto-commit recovery tests)
- [x] `npx vitest run tests/botCommands.test.ts` — 52/52 (added iterative-loop worktree preservation test)
- [x] Pre-existing `attachmentService.test.ts` failures confirmed on `main` (not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)