### PR TITLE
fix: prevent false-positive NOT_AUTHENTICATED when OpenCode runs subprocess CLIs

### DIFF
--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -64,6 +64,7 @@ export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: 
       unavailableCode: "OPENCODE_UNAVAILABLE",
       notAuthenticatedCode: "NOT_AUTHENTICATED",
       authFailurePattern: /not authenticated|API key not found|authentication required|set an Auth method/i,
+      authCheckOnlyStderr: true,
       authHint: "Use `/opencode-auth` to configure API keys.",
       timeoutCode: "TIMEOUT",
       failedCode: "FAILED",

--- a/src/utils/runProviderRequest.ts
+++ b/src/utils/runProviderRequest.ts
@@ -32,6 +32,12 @@ export interface ProviderRunnerConfig {
   notAuthenticatedCode?: string;
   /** Regex tested against stderr to detect authentication failures. */
   authFailurePattern?: RegExp;
+  /**
+   * If true, the clean-exit auth failure check tests only stderr (not stdout).
+   * Use for agentic CLIs whose stdout is task output and may contain arbitrary
+   * subprocess text (e.g. OpenCode running `gemini` commands as part of a task).
+   */
+  authCheckOnlyStderr?: boolean;
   /** User-facing hint appended to the auth failure message (e.g. "Use `/codex-auth` to upload credentials."). */
   authHint?: string;
   timeoutCode: string;
@@ -129,9 +135,11 @@ export async function runProviderRequest(
   }
   logger.debug({ stdoutLength: stdout.length }, `${config.logLabel} subprocess exited cleanly`);
 
-  // Detect auth prompts that the CLI printed to stdout instead of producing real output
+  // Detect auth prompts that the CLI printed to stdout instead of producing real output.
+  // For agentic CLIs (authCheckOnlyStderr=true), skip stdout — it's task output and may
+  // contain text from subprocesses the agent ran, causing false positives.
   if (config.authFailurePattern && config.notAuthenticatedCode) {
-    const combined = [stdout, stderr].join("\n");
+    const combined = config.authCheckOnlyStderr ? stderr : [stdout, stderr].join("\n");
     if (config.authFailurePattern.test(combined)) {
       const hint = config.authHint ? ` ${config.authHint}` : "";
       logger.warn({ stdout: stdout.slice(0, 1000), stderr }, `${config.logLabel} auth failure pattern matched on clean exit — logging output to assist diagnosis`);

--- a/src/utils/runProviderRequest.ts
+++ b/src/utils/runProviderRequest.ts
@@ -102,7 +102,11 @@ export async function runProviderRequest(
     }
 
     if (config.authFailurePattern && config.notAuthenticatedCode) {
-      const combined = [nodeError.stderr, nodeError.stdout, message].filter(Boolean).join("\n");
+      const combined = [
+        nodeError.stderr,
+        ...(config.authCheckOnlyStderr ? [] : [nodeError.stdout]),
+        message,
+      ].filter(Boolean).join("\n");
       if (config.authFailurePattern.test(combined)) {
         const hint = config.authHint ? ` ${config.authHint}` : "";
         logger.warn({ stderr: nodeError.stderr, stdout: nodeError.stdout?.slice(0, 1000) }, `${config.logLabel} auth failure pattern matched on process error — logging output to assist diagnosis`);

--- a/tests/opencodeExecutionService.test.ts
+++ b/tests/opencodeExecutionService.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import pino from "pino";
+
+vi.mock("../src/utils/spawnCollect.js");
+
+const { spawnCollect } = await import("../src/utils/spawnCollect.js");
+const mockSpawnCollect = vi.mocked(spawnCollect);
+
+const { OpencodeExecutionError, runOpencodeRequest } = await import("../src/services/opencodeExecutionService.js");
+
+const logger = pino({ level: "silent" });
+
+describe("runOpencodeRequest", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Bypass the pre-spawn auth check by providing an API key.
+    vi.stubEnv("DEEPSEEK_API_KEY", "test-key");
+  });
+
+  it("returns result text on clean exit", async () => {
+    mockSpawnCollect.mockResolvedValueOnce({ stdout: "task completed", stderr: "" });
+    const result = await runOpencodeRequest({ prompt: "do something", cwd: "/tmp", timeoutMs: 5000 }, logger);
+    expect(result.text).toBe("task completed");
+  });
+
+  it("does NOT throw NOT_AUTHENTICATED when auth failure text appears only in stdout (subprocess output, not OpenCode's own error)", async () => {
+    // OpenCode ran `gemini` as part of a task; gemini printed "not authenticated" which
+    // ended up in OpenCode's stdout. With authCheckOnlyStderr=true this must not be flagged.
+    mockSpawnCollect.mockResolvedValueOnce({
+      stdout: "I ran gemini and got: not authenticated\nset an Auth method in gemini config",
+      stderr: "",
+    });
+    const result = await runOpencodeRequest({ prompt: "investigate gemini", cwd: "/tmp", timeoutMs: 5000 }, logger);
+    expect(result.text).toContain("not authenticated");
+  });
+
+  it("throws NOT_AUTHENTICATED when auth failure pattern appears in stderr", async () => {
+    // OpenCode itself emitted the auth error to stderr — this is a real failure.
+    mockSpawnCollect.mockResolvedValueOnce({
+      stdout: "some partial output",
+      stderr: "Error: set an Auth method for opencode",
+    });
+    await expect(
+      runOpencodeRequest({ prompt: "do something", cwd: "/tmp", timeoutMs: 5000 }, logger)
+    ).rejects.toMatchObject({ code: "NOT_AUTHENTICATED", name: "OpencodeExecutionError" });
+  });
+
+  it("throws OPENCODE_UNAVAILABLE when binary is not found", async () => {
+    mockSpawnCollect.mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    await expect(
+      runOpencodeRequest({ prompt: "do something", cwd: "/tmp", timeoutMs: 5000 }, logger)
+    ).rejects.toMatchObject({ code: "OPENCODE_UNAVAILABLE", name: "OpencodeExecutionError" });
+  });
+
+  it("throws TIMEOUT when execution times out", async () => {
+    mockSpawnCollect.mockRejectedValueOnce(Object.assign(new Error("timed out"), { code: "ETIMEDOUT" }));
+    await expect(
+      runOpencodeRequest({ prompt: "do something", cwd: "/tmp", timeoutMs: 5000 }, logger)
+    ).rejects.toMatchObject({ code: "TIMEOUT", name: "OpencodeExecutionError" });
+  });
+});

--- a/tests/opencodeExecutionService.test.ts
+++ b/tests/opencodeExecutionService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import pino from "pino";
 
 vi.mock("../src/utils/spawnCollect.js");
@@ -15,6 +15,10 @@ describe("runOpencodeRequest", () => {
     vi.resetAllMocks();
     // Bypass the pre-spawn auth check by providing an API key.
     vi.stubEnv("DEEPSEEK_API_KEY", "test-key");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("returns result text on clean exit", async () => {

--- a/tests/opencodeExecutionService.test.ts
+++ b/tests/opencodeExecutionService.test.ts
@@ -45,6 +45,23 @@ describe("runOpencodeRequest", () => {
     ).rejects.toMatchObject({ code: "NOT_AUTHENTICATED", name: "OpencodeExecutionError" });
   });
 
+  it("does NOT throw NOT_AUTHENTICATED on non-zero exit when auth failure text appears only in stdout", async () => {
+    // A subprocess OpenCode ran printed auth-failure text to its stdout, which ended up in
+    // OpenCode's stdout. The process then exited non-zero (e.g. subprocess returned error).
+    // With authCheckOnlyStderr=true, stdout must be excluded from the auth pattern check
+    // in the catch block as well as the clean-exit path.
+    mockSpawnCollect.mockRejectedValueOnce(
+      Object.assign(new Error("Process exited with code 1"), {
+        killed: false,
+        stdout: "I ran gemini and got: not authenticated",
+        stderr: "some other error from opencode",
+      })
+    );
+    await expect(
+      runOpencodeRequest({ prompt: "do something", cwd: "/tmp", timeoutMs: 5000 }, logger)
+    ).rejects.not.toMatchObject({ code: "NOT_AUTHENTICATED" });
+  });
+
   it("throws OPENCODE_UNAVAILABLE when binary is not found", async () => {
     mockSpawnCollect.mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
     await expect(


### PR DESCRIPTION
## Summary

- OpenCode's stdout is full task output — when the agent runs subprocesses like `gemini` as part of a task, any auth-related text those tools print ends up in OpenCode's stdout
- The broad `authFailurePattern` regex (`not authenticated|API key not found|...`) was matching that text on clean exit and falsely throwing `NOT_AUTHENTICATED`, killing iterative `/plan` and `/revise` runs mid-loop
- Fix: add `authCheckOnlyStderr?: boolean` to `ProviderRunnerConfig`; when set, the clean-exit auth check tests only stderr (OpenCode's own diagnostics) rather than the combined stdout+stderr
- Set `authCheckOnlyStderr: true` for OpenCode; no behavior change for Gemini, Codex, or Claude

## Test plan

- [ ] `npm run check` passes (no type errors)
- [ ] `npx vitest run tests/opencodeExecutionService.test.ts` — 5 tests pass including:
  - Auth text in stdout only → does **not** throw NOT_AUTHENTICATED
  - Auth text in stderr → **does** throw NOT_AUTHENTICATED
- [ ] `npx vitest run` — full suite passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)