### PR TITLE
fix: land per-arg E2BIG cap + review env (dropped from #143 merge)

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -2520,24 +2520,39 @@ Output the result of the command or the link to the created issue.`;
     return null;
   }
 
-  private buildReviewRunners(guildId: string): {
+  private buildReviewRunners(input: {
+    guildId: string;
+    repoId: number;
+    threadId?: string | null;
+  }): {
     analyzer: ReviewModelRunner;
     reviewers: ReviewModelRunner[];
     judge: ReviewModelRunner;
     summarizer: ReviewModelRunner;
   } {
+    const { guildId } = input;
     const reviewConfig = this.db.getGuildReviewConfig(guildId);
     const slots = this.db.getReviewerSlots(guildId);
 
     const hasSlotOverride = (role: ReviewModelRole): boolean =>
       !!reviewConfig?.[`${role}_provider` as keyof typeof reviewConfig];
 
+    // Build the minimal execution env once for the whole review run. Without
+    // this, review subprocesses inherited the full parent process.env (the
+    // /ask path was migrated to a minimal env but /review was not), and — more
+    // subtly — the transport byte estimate undercounted because it saw no env
+    // while the kernel charged the inherited process.env against ARG_MAX.
+    const reviewEnv = this.installService.buildMinimalExecutionEnvironment({
+      repoId: input.repoId,
+      ...(input.threadId !== undefined ? { threadId: input.threadId } : {})
+    }).env;
+
     const buildRunner = (provider: AiProvider, defaultModel?: string | null, slotIndex?: number): ReviewModelRunner => ({
       provider,
       ...(defaultModel ? { model: defaultModel } : {}),
       label: slotIndex !== undefined ? `${AI_PROVIDER_LABELS[provider]} (Slot ${slotIndex})` : AI_PROVIDER_LABELS[provider],
       run: async ({ prompt, cwd, timeoutMs, model }) =>
-        this.runProviderText({ provider, prompt, cwd, timeoutMs, ...(model ? { model } : {}) })
+        this.runProviderText({ provider, prompt, cwd, timeoutMs, ...(model ? { model } : {}), env: reviewEnv })
     });
 
     if (slots.length > 0) {
@@ -2840,7 +2855,11 @@ Output the result of the command or the link to the created issue.`;
     }
 
     try {
-      const runners = this.buildReviewRunners(interaction.guildId);
+      const runners = this.buildReviewRunners({
+        guildId: interaction.guildId,
+        repoId: repo.id,
+        threadId: interaction.channelId
+      });
       const threadHistory = await this.buildThreadHistory(reviewThread);
       const result = await new Promise<Awaited<ReturnType<typeof runAdversarialReview>>>((resolve, reject) => {
         this.requestQueue.enqueue(interaction.guildId!, async () => {

--- a/src/services/claudeExecutionService.ts
+++ b/src/services/claudeExecutionService.ts
@@ -81,6 +81,14 @@ export async function runClaudeRequest(input: ClaudeExecutionInput, logger: Logg
     input,
     {
       binary: "claude",
+      // `claude`'s -p/--print is a BOOLEAN flag (non-interactive print mode), not
+      // a value-taking flag — the prompt is a positional argument. Modeling it as
+      // `prefixArgs: ["-p"]` + positional keeps the normal invocation byte-identical
+      // (`claude -p <prompt> ...`) while making the oversized path correct: the
+      // positional prompt is removed and piped via stdin (`claude -p ...` reads the
+      // prompt from stdin in print mode), instead of the fragile `-p "" + stdin`.
+      prefixArgs: ["-p"],
+      positionalPrompt: true,
       extraArgs: ["--output-format", "json", "--permission-mode", "bypassPermissions"],
       supportsStdinFallback: true,
       logLabel: "Claude",

--- a/src/services/codexExecutionService.ts
+++ b/src/services/codexExecutionService.ts
@@ -31,6 +31,9 @@ export async function runCodexRequest(input: CodexExecutionInput, logger: Logger
       prefixArgs: ["exec"],
       positionalPrompt: true,
       extraArgs: ["--dangerously-bypass-approvals-and-sandbox"],
+      // Verified contract (`codex exec --help`): "if not provided as an argument
+      // … instructions are read from stdin". The oversized path removes the
+      // positional prompt and pipes it via stdin — exactly this contract.
       supportsStdinFallback: true,
       logLabel: "Codex",
       makeError: (code, message) => new CodexExecutionError(code as CodexExecutionError["code"], message),

--- a/src/services/geminiExecutionService.ts
+++ b/src/services/geminiExecutionService.ts
@@ -33,6 +33,9 @@ export async function runGeminiRequest(input: GeminiExecutionInput, logger: Logg
     {
       binary: "gemini",
       extraArgs: ["--yolo"],
+      // Verified contract (`gemini --help`): "-p/--prompt … Appended to input on
+      // stdin (if any)." The oversized path keeps `-p ""` and pipes the prompt
+      // via stdin, so the empty -p value plus stdin yields exactly the prompt.
       supportsStdinFallback: true,
       logLabel: "Gemini",
       makeError: (code, message) => new GeminiExecutionError(code as GeminiExecutionError["code"], message),

--- a/src/services/installService.ts
+++ b/src/services/installService.ts
@@ -43,6 +43,42 @@ const GITHUB_CLI_VARS = new Set([
   "GIT_TERMINAL_PROMPT"
 ]);
 
+// Outbound proxy + custom TLS/CA configuration. A VM that routes egress through
+// a proxy or pins a private CA bundle needs these, or every provider/`gh` HTTPS
+// call fails under the minimal env. Both upper- and lower-case proxy spellings
+// are honored because different HTTP stacks read different cases.
+const NETWORK_TLS_VARS = new Set([
+  "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY",
+  "http_proxy", "https_proxy", "no_proxy", "all_proxy",
+  "NODE_EXTRA_CA_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR",
+  "CURL_CA_BUNDLE", "REQUESTS_CA_BUNDLE"
+]);
+
+// Runtime/config locators that redirect where a CLI finds its config/cache or
+// which API endpoint it talks to. Dropping these silently changes behavior
+// (wrong endpoint, missing config dir) instead of failing loudly, so they must
+// survive the minimal env when the deployment sets them.
+const RUNTIME_CONFIG_VARS = new Set([
+  "NODE_OPTIONS",
+  "XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME",
+  "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CONFIG_DIR",
+  "CODEX_HOME",
+  "OPENAI_BASE_URL", "OPENAI_API_BASE",
+  "GEMINI_BASE_URL", "GOOGLE_GEMINI_BASE_URL",
+  "OPENCODE_CONFIG"
+]);
+
+// Operator escape hatch: a comma/whitespace-separated list of additional env
+// var NAMES to pass through to provider subprocesses. Lets a deployment add
+// site-specific variables (e.g. an internal proxy or bespoke auth var) without
+// a code change. Only names are listed here; values still come from process.env.
+const EXTRA_ENV_ALLOWLIST_VAR = "EXTRA_EXECUTION_ENV_VARS";
+
+function parseExtraEnvAllowlist(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw.split(/[,\s]+/).map((entry) => entry.trim()).filter(Boolean);
+}
+
 export class InstallServiceError extends Error {
   public readonly code:
     | "UNKNOWN_PACKAGE"
@@ -360,15 +396,16 @@ export class InstallService {
     const packages: string[] = [];
     const env: NodeJS.ProcessEnv = {};
 
-    const allowedAuthVars = new Set([...PROVIDER_AUTH_VARS, ...GITHUB_CLI_VARS]);
+    const allowedVars = new Set<string>([
+      ...ESSENTIAL_ENV_VARS,
+      ...PROVIDER_AUTH_VARS,
+      ...GITHUB_CLI_VARS,
+      ...NETWORK_TLS_VARS,
+      ...RUNTIME_CONFIG_VARS,
+      ...parseExtraEnvAllowlist(sourceEnv[EXTRA_ENV_ALLOWLIST_VAR])
+    ]);
 
-    for (const key of ESSENTIAL_ENV_VARS) {
-      if (sourceEnv[key] !== undefined) {
-        env[key] = sourceEnv[key];
-      }
-    }
-
-    for (const key of allowedAuthVars) {
+    for (const key of allowedVars) {
       if (sourceEnv[key] !== undefined) {
         env[key] = sourceEnv[key];
       }

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -8,6 +8,15 @@ import { runProviderRequest } from "../utils/runProviderRequest.js";
 export const ALLOWED_OPENCODE_PROVIDERS = ["deepseek", "openai", "anthropic", "google", "xai", "groq", "openrouter", "together"] as const;
 export const OPENCODE_AUTH_PATH = join(homedir(), ".local", "share", "opencode", "auth.json");
 
+// opencode's `-f/--file` flag "attaches file(s) to the message" rather than
+// replacing the message — so an oversized prompt delivered purely via --file
+// with an empty message has undefined behavior (opencode may reject an empty
+// message). We keep a short, explicit directive message that points at the
+// attached file, which holds the full prompt. Robust regardless of whether
+// opencode treats the file as the prompt or as attached context.
+export const OPENCODE_TEMPFILE_DIRECTIVE =
+  "Read the attached file and follow its full contents as your prompt.";
+
 export interface OpencodeExecutionInput {
   prompt: string;
   cwd: string;
@@ -61,14 +70,22 @@ export async function runOpencodeRequest(input: OpencodeExecutionInput, logger: 
       extraArgs: ["--dangerously-skip-permissions"],
       supportsStdinFallback: false,
       reshapeArgsForTempfile: (_promptText: string, adjustedArgs: string[], tempFilePath: string) => {
-        const skipIdx = adjustedArgs.indexOf("--dangerously-skip-permissions");
+        // Re-insert a short directive message (the full prompt lives in the
+        // attached file) right after the `run` subcommand so opencode always
+        // has a non-empty, unambiguous instruction; then attach the file with
+        // `--file` before `--dangerously-skip-permissions` (order preserved).
+        const runIdx = adjustedArgs.indexOf("run");
+        const withMessage = [...adjustedArgs];
+        withMessage.splice(runIdx >= 0 ? runIdx + 1 : 0, 0, OPENCODE_TEMPFILE_DIRECTIVE);
+
+        const skipIdx = withMessage.indexOf("--dangerously-skip-permissions");
         if (skipIdx === -1) {
-          return [...adjustedArgs, "--file", tempFilePath];
+          return [...withMessage, "--file", tempFilePath];
         }
         return [
-          ...adjustedArgs.slice(0, skipIdx),
+          ...withMessage.slice(0, skipIdx),
           "--file", tempFilePath,
-          ...adjustedArgs.slice(skipIdx),
+          ...withMessage.slice(skipIdx),
         ];
       },
       logLabel: "OpenCode",

--- a/src/utils/runProviderRequest.ts
+++ b/src/utils/runProviderRequest.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import { spawnCollect, spawnCollectWithTransport, estimateSpawnPayloadBytes, DEFAULT_ARGV_TOTAL_LIMIT } from "./spawnCollect.js";
+import { spawnCollect, spawnCollectWithTransport, exceedsArgvLimits, DEFAULT_ARGV_TOTAL_LIMIT, MAX_SINGLE_ARG_BYTES } from "./spawnCollect.js";
 
 export interface ProviderRequestInput {
   prompt: string;
@@ -96,7 +96,12 @@ export async function runProviderRequest(
     args.push("--model", input.model);
   }
 
-  logger.debug({ argCount: args.length, totalBytes: estimateSpawnPayloadBytes(args, input.env), limitBytes: DEFAULT_ARGV_TOTAL_LIMIT, cwd: input.cwd, timeoutMs: input.timeoutMs }, `${config.logLabel} subprocess args`);
+  // When env is undefined the child inherits the full parent process.env, which
+  // the kernel counts against ARG_MAX — so estimate against the env we'll spawn.
+  const effectiveEnv = input.env ?? process.env;
+  const { exceeds: payloadExceedsLimits, totalBytes, maxArgBytes } = exceedsArgvLimits(args, effectiveEnv);
+
+  logger.debug({ argCount: args.length, totalBytes, maxArgBytes, limitBytes: DEFAULT_ARGV_TOTAL_LIMIT, maxArgLimitBytes: MAX_SINGLE_ARG_BYTES, cwd: input.cwd, timeoutMs: input.timeoutMs }, `${config.logLabel} subprocess args`);
 
   // Calculate which indices in `args` contain the prompt text (and its flag)
   const promptStartIdx = prefix.length + (config.cwdFlag ? 2 : 0);
@@ -104,16 +109,15 @@ export async function runProviderRequest(
     ? [promptStartIdx]
     : [promptStartIdx, promptStartIdx + 1];
 
-  const totalBytes = estimateSpawnPayloadBytes(args, input.env);
-
   // For providers using the -p <prompt> flag-pair pattern with stdin fallback,
   // keep the -p flag in args with an empty value and pipe the actual prompt via
   // stdin (the CLI appends stdin content to the -p value, e.g. Gemini).
   // This bypasses spawnCollectWithTransport's prompt-removal behavior which
-  // would remove -p entirely, breaking headless mode.
+  // would remove -p entirely, breaking headless mode. The trigger honors both
+  // the total payload limit and the per-argument MAX_ARG_STRLEN cap.
   const useFlagPairStdin = !config.positionalPrompt
     && config.supportsStdinFallback !== false
-    && totalBytes > DEFAULT_ARGV_TOTAL_LIMIT;
+    && payloadExceedsLimits;
 
   let stdout: string;
   let stderr: string;
@@ -137,7 +141,9 @@ export async function runProviderRequest(
           transport: "stdin" as const,
           transportReason: "oversized_flag_pair_stdin" as const,
           totalBytes,
+          maxArgBytes,
           limitBytes: DEFAULT_ARGV_TOTAL_LIMIT,
+          maxArgLimitBytes: MAX_SINGLE_ARG_BYTES,
           useFlagPairStdin: true,
           logLabel: config.logLabel,
         },

--- a/src/utils/spawnCollect.ts
+++ b/src/utils/spawnCollect.ts
@@ -52,6 +52,50 @@ export function estimateSpawnPayloadBytes(args: string[], env?: NodeJS.ProcessEn
  */
 export const DEFAULT_ARGV_TOTAL_LIMIT = 1.5 * 1024 * 1024; // 1.5 MB
 
+/**
+ * Per-argument safety threshold.
+ *
+ * Linux `execve` enforces a SECOND limit independent of the ARG_MAX total:
+ * `MAX_ARG_STRLEN` = `32 * PAGE_SIZE` = 131072 bytes (128 KB on 4 KB-page
+ * systems) caps the length of any *single* argv or env string. A single
+ * oversized prompt argument therefore triggers `E2BIG` long before the 1.5 MB
+ * total threshold is reached — and a prompt in the 128 KB–1.5 MB band is the
+ * most common real case. We move the prompt off argv when any single argument
+ * approaches this cap, leaving ~6 KB of headroom below the hard 131072 ceiling.
+ */
+export const MAX_SINGLE_ARG_BYTES = 120 * 1024; // 122_880 bytes
+
+/** Largest single-argument size in bytes (UTF-8) across an argv array. */
+export function maxArgByteLength(args: string[]): number {
+  let max = 0;
+  for (const arg of args) {
+    const len = Buffer.byteLength(arg, "utf-8");
+    if (len > max) max = len;
+  }
+  return max;
+}
+
+/**
+ * Decide whether an argv/env payload must be moved off the command line to
+ * avoid `E2BIG`. Returns `exceeds: true` when EITHER the combined payload
+ * exceeds `DEFAULT_ARGV_TOTAL_LIMIT` OR any single argument exceeds
+ * `MAX_SINGLE_ARG_BYTES` (the per-string kernel cap). Both limits must be
+ * honored: the total guards against many medium args + a large env, while the
+ * per-arg guard catches a single huge prompt that fits well under the total.
+ */
+export function exceedsArgvLimits(
+  args: string[],
+  env?: NodeJS.ProcessEnv,
+): { exceeds: boolean; totalBytes: number; maxArgBytes: number } {
+  const totalBytes = estimateSpawnPayloadBytes(args, env);
+  const maxArgBytes = maxArgByteLength(args);
+  return {
+    exceeds: totalBytes > DEFAULT_ARGV_TOTAL_LIMIT || maxArgBytes > MAX_SINGLE_ARG_BYTES,
+    totalBytes,
+    maxArgBytes,
+  };
+}
+
 // ── Temp file helpers for prompt transport ────────────────────────────────
 
 const TEMP_DIR_PREFIX = "actuarius-prompt-";
@@ -199,9 +243,9 @@ export function decidePromptTransport(
     }
   }
 
-  const totalBytes = estimateSpawnPayloadBytes(args, env);
+  const { exceeds, totalBytes } = exceedsArgvLimits(args, env);
 
-  if (totalBytes <= DEFAULT_ARGV_TOTAL_LIMIT) {
+  if (!exceeds) {
     return { transport: "argv", args, totalBytes, transportReason: "under_limit" };
   }
 
@@ -350,10 +394,16 @@ export async function spawnCollectWithTransport(
     logLabel,
   } = options;
 
+  // When env is undefined, `spawnCollect` lets the child inherit the full
+  // parent `process.env`. The kernel charges those bytes against ARG_MAX, so
+  // the size estimate must count them too — otherwise we undercount and skip a
+  // fallback that was actually needed. Estimate against the env we will spawn.
+  const estimationEnv = env ?? process.env;
+
   const decision = decidePromptTransport(
     args,
     promptArgIndices,
-    env,
+    estimationEnv,
     supportsStdinFallback,
     tempfileFlag,
     reshapeArgsForTempfile,
@@ -373,7 +423,9 @@ export async function spawnCollectWithTransport(
         transport: decision.transport,
         transportReason: decision.transportReason,
         totalBytes: decision.totalBytes,
+        maxArgBytes: maxArgByteLength(args),
         limitBytes: DEFAULT_ARGV_TOTAL_LIMIT,
+        maxArgLimitBytes: MAX_SINGLE_ARG_BYTES,
         useFlagPairStdin: false,
         logLabel,
       },

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -1412,7 +1412,7 @@ describe("ActuariusBot review runner selection", () => {
     (bot as any).config.enableCodexExecution = true;
     (bot as any).config.enableGeminiExecution = true;
 
-    const runners = (bot as any).buildReviewRunners("guild-1");
+    const runners = (bot as any).buildReviewRunners({ guildId: "guild-1", repoId: 1 });
 
     expect(runners.reviewers).toHaveLength(3);
     expect(runners.reviewers.map((runner: { provider: string; model?: string }) => ({
@@ -1441,7 +1441,7 @@ describe("ActuariusBot review runner selection", () => {
       ])
     });
 
-    const runners = (bot as any).buildReviewRunners("guild-1");
+    const runners = (bot as any).buildReviewRunners({ guildId: "guild-1", repoId: 1 });
 
     expect(runners.reviewers).toHaveLength(3);
     expect(runners.analyzer.provider).toBe("claude");
@@ -2898,7 +2898,7 @@ describe("ActuariusBot model-select command", () => {
     (bot as any).config.enableGeminiExecution = true;
     (bot as any).config.enableCodexExecution = true;
 
-    const runners = (bot as any).buildReviewRunners("guild-1");
+    const runners = (bot as any).buildReviewRunners({ guildId: "guild-1", repoId: 1 });
 
     expect(runners.analyzer.provider).toBe("gemini");
     expect(runners.analyzer.model).toBe("gemini-2.0-flash");

--- a/tests/claudeExecutionService.test.ts
+++ b/tests/claudeExecutionService.test.ts
@@ -118,7 +118,7 @@ describe("runClaudeRequest", () => {
         file: "claude",
         args: ["-p", "my prompt", "--output-format", "json", "--permission-mode", "bypassPermissions"],
         cwd: "/tmp",
-        promptArgIndices: [0, 1],
+        promptArgIndices: [1],
       })
     );
   });

--- a/tests/claudeExecutionService.test.ts
+++ b/tests/claudeExecutionService.test.ts
@@ -1,7 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import pino from "pino";
 
-vi.mock("../src/utils/spawnCollect.js");
+// Mock only the process-spawning functions; keep the real (pure) byte-math
+// helpers like exceedsArgvLimits/estimateSpawnPayloadBytes and the size
+// constants so the transport decision runs for real.
+vi.mock("../src/utils/spawnCollect.js", async (importActual) => {
+  const actual = await importActual<typeof import("../src/utils/spawnCollect.js")>();
+  return {
+    ...actual,
+    spawnCollect: vi.fn(),
+    spawnCollectWithTransport: vi.fn(),
+  };
+});
 
 const { spawnCollectWithTransport } = await import("../src/utils/spawnCollect.js");
 const mockSpawnCollectWithTransport = vi.mocked(spawnCollectWithTransport);

--- a/tests/opencodeExecutionService.test.ts
+++ b/tests/opencodeExecutionService.test.ts
@@ -20,7 +20,7 @@ vi.mock("../src/utils/spawnCollect.js", async (importActual) => {
 const { spawnCollectWithTransport } = await import("../src/utils/spawnCollect.js");
 const mockSpawnCollectWithTransport = vi.mocked(spawnCollectWithTransport);
 
-const { OpencodeExecutionError, runOpencodeRequest } = await import("../src/services/opencodeExecutionService.js");
+const { OpencodeExecutionError, runOpencodeRequest, OPENCODE_TEMPFILE_DIRECTIVE } = await import("../src/services/opencodeExecutionService.js");
 
 const logger = pino({ level: "silent" });
 
@@ -140,7 +140,7 @@ describe("runOpencodeRequest", () => {
     const adjusted = ["run", "--dir", "/work", "--dangerously-skip-permissions", "--model", "o4-mini"];
     const result = reshapeArgsForTempfile("big prompt", adjusted, "/tmp/prompt.txt");
     expect(result).toEqual([
-      "run", "--dir", "/work",
+      "run", OPENCODE_TEMPFILE_DIRECTIVE, "--dir", "/work",
       "--file", "/tmp/prompt.txt",
       "--dangerously-skip-permissions",
       "--model", "o4-mini",
@@ -155,7 +155,7 @@ describe("runOpencodeRequest", () => {
     const adjusted = ["run", "--dir", "/work", "--model", "o4-mini"];
     const result = reshapeArgsForTempfile("big prompt", adjusted, "/tmp/prompt.txt");
     expect(result).toEqual([
-      "run", "--dir", "/work", "--model", "o4-mini",
+      "run", OPENCODE_TEMPFILE_DIRECTIVE, "--dir", "/work", "--model", "o4-mini",
       "--file", "/tmp/prompt.txt",
     ]);
   });

--- a/tests/opencodeExecutionService.test.ts
+++ b/tests/opencodeExecutionService.test.ts
@@ -5,7 +5,17 @@ vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
 }));
 
-vi.mock("../src/utils/spawnCollect.js");
+// Mock only the process-spawning functions; keep the real (pure) byte-math
+// helpers like exceedsArgvLimits/estimateSpawnPayloadBytes and the size
+// constants so the transport decision runs for real.
+vi.mock("../src/utils/spawnCollect.js", async (importActual) => {
+  const actual = await importActual<typeof import("../src/utils/spawnCollect.js")>();
+  return {
+    ...actual,
+    spawnCollect: vi.fn(),
+    spawnCollectWithTransport: vi.fn(),
+  };
+});
 
 const { spawnCollectWithTransport } = await import("../src/utils/spawnCollect.js");
 const mockSpawnCollectWithTransport = vi.mocked(spawnCollectWithTransport);

--- a/tests/opencodeExecutionService.test.ts
+++ b/tests/opencodeExecutionService.test.ts
@@ -189,8 +189,19 @@ describe("runOpencodeRequest", () => {
     });
   });
 
-  it("throws NOT_AUTHENTICATED when auth failure pattern matches on clean exit stdout", async () => {
+  it("does NOT treat an auth-like pattern on clean-exit stdout as NOT_AUTHENTICATED (authCheckOnlyStderr)", async () => {
+    // opencode is an agentic CLI: its stdout is task output and may contain
+    // auth-like strings emitted by subprocesses it runs (e.g. a nested gemini).
+    // Per authCheckOnlyStderr, only stderr is inspected for auth failures, so a
+    // clean exit with this text on stdout must be returned as the result, not
+    // misclassified as an auth error.
     mockSpawnCollectWithTransport.mockResolvedValueOnce({ stdout: "API key not found. Use /opencode-auth to set one.", stderr: "" });
+    const result = await runOpencodeRequest({ prompt: "hello", cwd: "/tmp", timeoutMs: 5000 }, logger);
+    expect(result.text).toBe("API key not found. Use /opencode-auth to set one.");
+  });
+
+  it("throws NOT_AUTHENTICATED when auth failure pattern matches on clean exit stderr", async () => {
+    mockSpawnCollectWithTransport.mockResolvedValueOnce({ stdout: "", stderr: "API key not found. Use /opencode-auth to set one." });
     await expect(runOpencodeRequest({ prompt: "hello", cwd: "/tmp", timeoutMs: 5000 }, logger)).rejects.toMatchObject({
       code: "NOT_AUTHENTICATED",
       name: "OpencodeExecutionError",

--- a/tests/promptTransport.test.ts
+++ b/tests/promptTransport.test.ts
@@ -7,6 +7,9 @@ import {
   estimateEnvBytes,
   estimateSpawnPayloadBytes,
   DEFAULT_ARGV_TOTAL_LIMIT,
+  MAX_SINGLE_ARG_BYTES,
+  maxArgByteLength,
+  exceedsArgvLimits,
   decidePromptTransport,
   writeTempPromptFile,
   cleanupTempPromptFile,
@@ -104,6 +107,55 @@ describe("DEFAULT_ARGV_TOTAL_LIMIT", () => {
   });
 });
 
+describe("MAX_SINGLE_ARG_BYTES", () => {
+  it("is 120 KB (122_880 bytes) — below the 128 KB Linux MAX_ARG_STRLEN cap", () => {
+    expect(MAX_SINGLE_ARG_BYTES).toBe(122_880);
+    // Must stay strictly under the hard kernel limit of 131072 bytes.
+    expect(MAX_SINGLE_ARG_BYTES).toBeLessThan(131_072);
+  });
+});
+
+describe("maxArgByteLength", () => {
+  it("returns 0 for an empty array", () => {
+    expect(maxArgByteLength([])).toBe(0);
+  });
+
+  it("returns the largest single-arg UTF-8 byte length, not the sum", () => {
+    expect(maxArgByteLength(["a", "bbbb", "cc"])).toBe(4);
+  });
+
+  it("counts multi-byte characters by UTF-8 byte length", () => {
+    // "你好" = 6 bytes, longer than the 5-byte ASCII string
+    expect(maxArgByteLength(["hello", "你好"])).toBe(6);
+  });
+});
+
+describe("exceedsArgvLimits", () => {
+  it("does not flag a small payload", () => {
+    const result = exceedsArgvLimits(["-p", "hello"]);
+    expect(result.exceeds).toBe(false);
+  });
+
+  it("flags a single argument over the per-arg cap even when the total is well under 1.5 MB", () => {
+    // 200 KB prompt: total ~200 KB (under DEFAULT_ARGV_TOTAL_LIMIT) but the
+    // single arg exceeds MAX_SINGLE_ARG_BYTES — the band that used to E2BIG.
+    const prompt = "x".repeat(200 * 1024);
+    const result = exceedsArgvLimits(["-p", prompt]);
+    expect(result.totalBytes).toBeLessThan(DEFAULT_ARGV_TOTAL_LIMIT);
+    expect(result.maxArgBytes).toBeGreaterThan(MAX_SINGLE_ARG_BYTES);
+    expect(result.exceeds).toBe(true);
+  });
+
+  it("flags an aggregate payload over the total limit even when each arg is small", () => {
+    // Many small args summing past the total, none individually over the cap.
+    const args = Array.from({ length: 40 }, () => "y".repeat(50 * 1024));
+    const result = exceedsArgvLimits(args);
+    expect(result.maxArgBytes).toBeLessThan(MAX_SINGLE_ARG_BYTES);
+    expect(result.totalBytes).toBeGreaterThan(DEFAULT_ARGV_TOTAL_LIMIT);
+    expect(result.exceeds).toBe(true);
+  });
+});
+
 describe("decidePromptTransport", () => {
   it("returns argv transport when payload fits under threshold", () => {
     const args = ["-p", "short prompt"];
@@ -118,6 +170,29 @@ describe("decidePromptTransport", () => {
     const decision = decidePromptTransport([], []);
     expect(decision.transport).toBe("argv");
     expect(decision.args).toEqual([]);
+  });
+
+  it("moves a 200 KB prompt off argv even though the total is under 1.5 MB (per-arg cap)", () => {
+    // Regression: a single prompt in the 128 KB–1.5 MB band exceeds Linux's
+    // MAX_ARG_STRLEN per-argument cap and E2BIGs, even though the total
+    // payload is far below DEFAULT_ARGV_TOTAL_LIMIT. The fallback must fire.
+    const prompt = "x".repeat(200 * 1024);
+    const args = ["-p", prompt];
+    const decision = decidePromptTransport(args, [0, 1]);
+    expect(decision.totalBytes).toBeLessThan(DEFAULT_ARGV_TOTAL_LIMIT);
+    expect(decision.transport).toBe("stdin");
+    expect(decision.args).toEqual([]);
+    expect(decision.stdinPayload).toBe(prompt);
+  });
+
+  it("uses tempfile for a 200 KB positional prompt when stdin is unsupported (per-arg cap)", () => {
+    const prompt = "z".repeat(200 * 1024);
+    const args = ["run", prompt, "--flag"];
+    const decision = decidePromptTransport(args, [1], undefined, false, ["--file", "<path>"]);
+    expect(decision.totalBytes).toBeLessThan(DEFAULT_ARGV_TOTAL_LIMIT);
+    expect(decision.transport).toBe("tempfile");
+    expect(decision.args).toEqual(["run", "--file", "<path>", "--flag"]);
+    expect(decision.stdinPayload).toBe(prompt);
   });
 
   it("returns stdin transport when payload exceeds threshold (default stdin support)", () => {

--- a/tests/spawnCollect.test.ts
+++ b/tests/spawnCollect.test.ts
@@ -150,8 +150,11 @@ describe("spawnCollectWithTransport — argv transport", () => {
     ).rejects.toMatchObject({ code: "EMSGSIZE" });
   });
 
-  it("rejects with E2BIG when oversized but promptArgIndices is empty", async () => {
+  it("rejects with a command-line-too-long error when oversized but promptArgIndices is empty", async () => {
     const hugeArg = "x".repeat(2 * 1024 * 1024);
+    // The OS rejects the over-long argv before the process starts. The errno
+    // differs by platform: E2BIG on Linux (execve), ENAMETOOLONG on Windows
+    // (CreateProcess via libuv). Both signal the same unrecoverable condition.
     await expect(
       spawnCollectWithTransport({
         file: node,
@@ -161,7 +164,7 @@ describe("spawnCollectWithTransport — argv transport", () => {
         timeoutMs,
         maxBuffer: 1024,
       })
-    ).rejects.toMatchObject({ code: "E2BIG" });
+    ).rejects.toMatchObject({ code: expect.stringMatching(/^(E2BIG|ENAMETOOLONG)$/) });
   });
 });
 


### PR DESCRIPTION
## Why

PR #143 (hybrid prompt transport) was squash-merged into `main` **without two follow-up commits** that fix the actual `spawn E2BIG` failure mode. Production (running merged `main`) still throws `spawn E2BIG` — most recently on a Codex **Revise** planner:

```
errorCode:"E2BIG","message":"spawn E2BIG","msg":"Codex subprocess failed"
```

Root cause: the merged code gates the off-argv fallback on **total** payload only (`totalBytes <= DEFAULT_ARGV_TOTAL_LIMIT`, 1.5 MB). But Linux also enforces **`MAX_ARG_STRLEN`** — a 128 KB cap on any *single* argument. A prompt in the 128 KB–1.5 MB band (a diff + revision request) E2BIGs without ever crossing the total threshold. This is the most common real case.

## What

Re-lands the dropped work on top of current `main` (cherry-picked, conflicts resolved, `authCheckOnlyStderr` from #142 preserved):

**Per-arg E2BIG fix (the production fix):**
- `MAX_SINGLE_ARG_BYTES` (120 KB) + `exceedsArgvLimits`; `decidePromptTransport` and `runProviderRequest` now offload the prompt when **either** the total OR any single argument exceeds its limit.

**Review-path env fix:**
- `buildReviewRunners` threads a minimal execution env (was inheriting full `process.env`); the byte estimate now uses `env ?? process.env` so it matches what the kernel charges.

**MEDIUM findings (CLI contracts verified against real `--help`):**
- **Claude**: `-p/--print` is a boolean, not a value flag — modeled as positional with `prefixArgs:["-p"]` so the oversized path is `claude -p …` + stdin (its real contract) instead of the fragile `-p "" + stdin`.
- **Codex/Gemini**: verified correct (codex reads stdin; gemini appends `-p` value to stdin), documented.
- **OpenCode**: `--file` *attaches* to the message — re-insert a short directive message so it's never empty.
- **Minimal-env allowlist**: add proxy/TLS-CA/runtime-config vars + an `EXTRA_EXECUTION_ENV_VARS` operator escape hatch.

**Drive-by:** corrected the opencode auth-detection test that #142 left failing on `main` (stdout auth patterns are intentionally ignored under `authCheckOnlyStderr`).

## Validation

- `npm run check` clean; affected suites green (309 passing). Full suite back to the same pre-existing environmental-only failures (bash `.sh` scripts + image test; pass on Linux/CI).

Re-lands work from the now-merged #143 branch. Relates to #141.
