### PR TITLE
docs: disk-fill lessons learned + prevent_destroy guard + auth fix + cache rotation + Rust stubs

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -87,6 +87,15 @@ PYEOF
   fi
 fi
 
+# ── cache rotation ────────────────────────────────────────────
+# Clean accumulating caches on every container start to prevent
+# incremental disk fill (compounding npm/cargo/opencode caches).
+rm -rf "$HOME/.npm/_cacache" 2>/dev/null || true
+rm -rf "$HOME/.cache/"* 2>/dev/null || true
+rm -rf "$HOME/.cargo/registry/cache" 2>/dev/null || true
+rm -f "$HOME/.local/share/opencode/opencode.db" "$HOME/.local/share/opencode/opencode.db-shm" "$HOME/.local/share/opencode/opencode.db-wal" 2>/dev/null || true
+rm -rf "$HOME/.codex/tmp" "$HOME/.codex/sessions" 2>/dev/null || true
+
 git config --global user.name "$GIT_USER_NAME"
 git config --global user.email "$GIT_USER_EMAIL"
 
@@ -94,5 +103,19 @@ if [ -n "${GH_TOKEN:-}" ]; then
   git config --global --replace-all credential.https://github.com.helper \
     '!f() { echo username=x-token; printf "password=%s\n" "$GH_TOKEN"; }; f'
 fi
+
+# Stub out global Rust to prevent ~/.rustup and ~/.cargo disk bloat.  The
+# scoped installer (/install rustup-default-stable) downloads its own
+# rustup-init and places wrappers in a scoped bin dir that comes first in
+# PATH, so these stubs do NOT interfere with scoped Rust access.
+for tool in rustup cargo rustc rustfmt; do
+  if [ -f "/usr/local/bin/$tool" ]; then continue; fi
+  cat > "/usr/local/bin/$tool" <<'RUSTSTUB'
+#!/bin/sh
+echo "Rust toolchain is not available globally. Use /install rustup-default-stable to request scoped Rust access." >&2
+exit 1
+RUSTSTUB
+  chmod +x "/usr/local/bin/$tool"
+done
 
 exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -112,7 +112,7 @@ for tool in rustup cargo rustc rustfmt; do
   if [ -f "/usr/local/bin/$tool" ]; then continue; fi
   cat > "/usr/local/bin/$tool" <<'RUSTSTUB'
 #!/bin/sh
-echo "Rust toolchain is not available globally. Use /install rustup-default-stable to request scoped Rust access." >&2
+echo "Cannot run rust on this VM, please use CI to validate build." >&2
 exit 1
 RUSTSTUB
   chmod +x "/usr/local/bin/$tool"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -91,7 +91,7 @@ fi
 # Clean accumulating caches on every container start to prevent
 # incremental disk fill (compounding npm/cargo/opencode caches).
 rm -rf "$HOME/.npm/_cacache" 2>/dev/null || true
-rm -rf "$HOME/.cache/"* 2>/dev/null || true
+rm -rf "$HOME/.cache" 2>/dev/null || true
 rm -rf "$HOME/.cargo/registry/cache" 2>/dev/null || true
 rm -f "$HOME/.local/share/opencode/opencode.db" "$HOME/.local/share/opencode/opencode.db-shm" "$HOME/.local/share/opencode/opencode.db-wal" 2>/dev/null || true
 rm -rf "$HOME/.codex/tmp" "$HOME/.codex/sessions" 2>/dev/null || true
@@ -108,14 +108,16 @@ fi
 # scoped installer (/install rustup-default-stable) downloads its own
 # rustup-init and places wrappers in a scoped bin dir that comes first in
 # PATH, so these stubs do NOT interfere with scoped Rust access.
+STUB_DIR="$HOME/.local/bin"
+mkdir -p "$STUB_DIR"
+export PATH="$STUB_DIR:$PATH"
 for tool in rustup cargo rustc rustfmt; do
-  if [ -f "/usr/local/bin/$tool" ]; then continue; fi
-  cat > "/usr/local/bin/$tool" <<'RUSTSTUB'
+  cat > "$STUB_DIR/$tool" <<'RUSTSTUB'
 #!/bin/sh
 echo "Cannot run rust on this VM, please use CI to validate build." >&2
 exit 1
 RUSTSTUB
-  chmod +x "/usr/local/bin/$tool"
+  chmod +x "$STUB_DIR/$tool"
 done
 
 exec "$@"

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -50,7 +50,7 @@ Two gotchas:
 ```bash
 rm -rf ~/.npm/_cacache ~/.gradle/caches ~/.cargo/registry ~/.cache   # caches
 rm -rf ~/.rustup ~/.cargo                                              # Rust toolchain
-rm -rf /data/tool-installs/repo/<id>/{java-temurin,android-sdk}        # JVM/Android toolchains
+rm -rf /data/tool-installs/*/*/{java-temurin,android-sdk}             # JVM/Android toolchains (all repos)
 ```
 Do NOT delete `.npm-global` (the provider CLIs) or auth files (`.codex/auth.json`, `.local/share/opencode/auth.json`, `.gemini` creds).
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -48,7 +48,7 @@ Two gotchas:
 
 **Fix (reclaim, run inside the container):** all of these regenerate or are re-`/install`able:
 ```bash
-rm -rf ~/.npm/_cacache ~/.gradle/caches ~/.cargo/registry ~/.cache/*   # caches
+rm -rf ~/.npm/_cacache ~/.gradle/caches ~/.cargo/registry ~/.cache   # caches
 rm -rf ~/.rustup ~/.cargo                                              # Rust toolchain
 rm -rf /data/tool-installs/repo/<id>/{java-temurin,android-sdk}        # JVM/Android toolchains
 ```

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -35,6 +35,27 @@ On Container-Optimized OS, `blkid` may return false on a freshly attached disk (
 
 **Rule:** Never use `blkid` as the sole guard before formatting a disk. Always try mount first.
 
+## `/data` fills from per-repo toolchains and build caches, not worktrees
+
+When the 10 GB `/data` disk hits `ENOSPC`, the bot fails to start (npm can't unpack provider CLIs, git can't write `.gitconfig.lock`). The culprit is two append-mostly sources — *not* worktrees, which are bounded by request count and partly reaped:
+
+- **Per-repo toolchains** installed via `/install`, under `/data/tool-installs/<scope>/<id>/`. The JVM/Android stack is heaviest — one Android repo pulled ~1.1 GB (`java-temurin` ~500 MB + `android-sdk` ~600 MB).
+- **Build-tool caches** in the container `$HOME` (`/data/home/appuser`): `.npm` (npm cache), `.gradle/caches`, `.cargo/registry`, `.rustup` (Rust toolchains), `.cache`.
+
+Two gotchas:
+- **Host vs container path:** the disk is `/mnt/disks/data` on the COS host but `/data` inside the container (`$HOME` = `/data/home/appuser`). `rm` against the wrong namespace silently no-ops — `df`/`du` won't budge.
+- **Installs are explicit and admin-gated** (`/install`) — nothing auto-installs toolchains. Deleting a toolchain's files does NOT clear its `install_requests` row, so `buildMinimalExecutionEnvironment` keeps injecting the dead `bin_path` onto `PATH` (harmless), and the bot won't reinstall until `/install` is re-run.
+
+**Fix (reclaim, run inside the container):** all of these regenerate or are re-`/install`able:
+```bash
+rm -rf ~/.npm/_cacache ~/.gradle/caches ~/.cargo/registry ~/.cache/*   # caches
+rm -rf ~/.rustup ~/.cargo                                              # Rust toolchain
+rm -rf /data/tool-installs/repo/<id>/{java-temurin,android-sdk}        # JVM/Android toolchains
+```
+Do NOT delete `.npm-global` (the provider CLIs) or auth files (`.codex/auth.json`, `.local/share/opencode/auth.json`, `.gemini` creds).
+
+**Rule:** When `/data` approaches full, reclaim caches + unused per-repo toolchains first. The durable fix is a larger disk — follow the snapshot-first resize procedure (confirm `prevent_destroy`, snapshot `actuarius-data`, bump `size` in `infra/compute.tf`, `terraform apply`, then `resize2fs`); a botched resize previously caused full data loss.
+
 ## Updating `scripts/redeploy.sh` requires a manual refresh on the VM
 
 `infra/startup.sh` fetches `scripts/redeploy.sh` from VM metadata at boot and saves it to `/var/redeploy.sh`. When Terraform updates the `env-redeploy-script` metadata key (e.g. adding a new env var), the VM is not rebooted, so `/var/redeploy.sh` stays stale.

--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -3,6 +3,13 @@ resource "google_compute_disk" "data" {
   type = "pd-standard"
   zone = var.gcp_zone
   size = 10 # GB — separate persistent disk so /data survives VM deletion
+
+  lifecycle {
+    # Guard against destroy/recreate (which previously caused full data loss).
+    # A size increase is an in-place update and is unaffected; this only blocks
+    # Terraform from tearing the disk down. See docs/lessons-learned.md.
+    prevent_destroy = true
+  }
 }
 
 resource "google_compute_instance" "actuarius" {

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -27,7 +27,7 @@ import type { AiProvider, ReviewModelRole, RepoRow, RequestStatus } from "../db/
 import { commandBuilders } from "./commands.js";
 import { buildHelpText } from "./messageTemplates.js";
 import { buildRepoChannelName, buildThreadName } from "./naming.js";
-import { forceRefreshGitHubAuth, getGitHubCommandEnvironment } from "../services/githubAuthService.js";
+import { ensureGitHubCliAuthenticated, forceRefreshGitHubAuth, getGitHubCommandEnvironment } from "../services/githubAuthService.js";
 import {
   GitHubIssueLookupError,
   GitHubRepoLookupError,
@@ -2380,15 +2380,17 @@ Output the result of the command or the link to the created issue.`;
 
   private async ensureGitHubCliAccess(interaction: ChatInputCommandInteraction, commands: string[]): Promise<boolean> {
     try {
+      await ensureGitHubCliAuthenticated();
       const { spawnCollect } = await import("../utils/spawnCollect.js");
-      await spawnCollect("gh", ["auth", "token"], {
+      await spawnCollect("gh", ["auth", "token", "--hostname", "github.com"], {
         cwd: process.cwd(),
         env: getGitHubCommandEnvironment(),
         timeoutMs: 10_000,
         maxBuffer: 4 * 1024
       });
       return true;
-    } catch {
+    } catch (err) {
+      this.logger.warn({ err }, "GitHub CLI access check failed");
       await interaction.reply({
         content:
           `GitHub CLI is not authenticated. Configure GitHub App credentials or \`GH_TOKEN\`, or run \`gh auth login\` on the host before using ${commands.join(" or ")}.`,


### PR DESCRIPTION
### Summary

Collection of fixes and hardening from live production issues, all discovered from two `/data` disk-full incidents.

---

### Changes

**1. Disk-fill lessons learned** (`docs/lessons-learned.md`)
- Documented root cause: per-repo toolchains (JVM/Android ~1.1 GB/repo) + build caches (npm, gradle, cargo, rustup, opencode.db) compound on the 10 GB disk.
- Noted host-vs-container path gotcha: `/mnt/disks/data` on host vs `/data` in container — wrong namespace `rm` silently no-ops.
- Documented reclaim procedure and confirmed installs are admin-gated (no auto-install).

**2. `prevent_destroy` guard on data disk** (`infra/compute.tf`)
- Added `lifecycle { prevent_destroy = true }` to `google_compute_disk.data` — prevents Terraform from tearing down the persistent disk, which previously caused total data loss.

**3. GitHub auth reliability fix** (`src/discord/bot.ts`)
- `ensureGitHubCliAccess()` now calls `ensureGitHubCliAuthenticated()` before checking `gh auth token` — this triggers a token refresh on-demand instead of waiting for the auto-retry loop.
- Added explicit `--hostname github.com` to match the `gh auth login` command used during setup.
- Error now logged for diagnostics.

**4. Cache rotation on container start** (`docker/entrypoint.sh`)
- Clears npm `_cacache`, `.cache`, `.cargo/registry/cache`, `opencode.db`, and codex tmp/sessions on every container start to prevent incremental disk fill.

**5. Rust tool stubs** (`docker/entrypoint.sh`)
- `rustup`, `cargo`, `rustc`, `rustfmt` are stubbed to error: "Cannot run rust on this VM, please use CI to validate build."
- Scoped `/install rustup-default-stable` still works (downloads its own `rustup-init` and uses scoped bin dirs).
