### PR TITLE
[codex] Preserve failed plan worktrees

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -573,7 +573,13 @@ export class ActuariusBot {
 
     const latestRequest = this.db.getLatestRequestWithWorkspaceByThreadId(message.channelId);
     const existingWorktreePath = latestRequest?.worktree_path;
-    if (!existingWorktreePath) return;
+    if (!existingWorktreePath) {
+      const latestThreadRequest = this.db.getRequestByThreadId(message.channelId);
+      if (latestThreadRequest?.status === "failed" && !latestThreadRequest.worktree_path) {
+        await message.reply("This request failed and no tracked worktree is available to continue. Start a new `/plan` request from the connected repo channel.");
+      }
+      return;
+    }
 
     if (!existsSync(existingWorktreePath)) {
       await message.reply("The worktree for this thread no longer exists (the bot may have been restarted or migrated). Use `/ask` to start a new request.");
@@ -2279,7 +2285,7 @@ export class ActuariusBot {
     }
 
     const prompt = interaction.options.getString("prompt", true).trim();
-    const iterative = interaction.options.getBoolean("iterative") ?? false;
+    const iterative = interaction.options.getBoolean("iterative") ?? true;
     if (!prompt) {
       await interaction.reply({ content: "Prompt cannot be empty.", ephemeral: true });
       return;
@@ -3391,28 +3397,12 @@ Output the result of the command or the link to the created issue.`;
       statusFinalized = true;
     };
 
-    const cleanupFailedWorktree = async (): Promise<void> => {
-      if (!worktreePath || !branchName) {
+    const sendPreservedWorktreeNotice = async (): Promise<void> => {
+      if (!worktreePath || !branchName || !threadChannel?.isThread()) {
         return;
       }
 
-      try {
-        await deleteRequestBranch(
-          this.config.reposRootPath,
-          {
-            owner: input.repo.owner,
-            repo: input.repo.repo,
-            fullName: input.repo.fullName
-          },
-          {
-            branchName,
-            worktreePath
-          }
-        );
-        this.db.updateRequestWorkspace(input.requestId, null, null);
-      } catch (cleanupError) {
-        this.logger.warn({ error: cleanupError, requestId: input.requestId, worktreePath, branchName }, "Plan request worktree cleanup failed");
-      }
+      await threadChannel.send(`The request branch \`${branchName}\` remains attached. Send a follow-up message or run \`/revise\` to continue; use \`/delete\` if you want to remove it.`);
     };
 
     try {
@@ -3516,7 +3506,7 @@ Output the result of the command or the link to the created issue.`;
       if (!planText.trim()) {
         markFailed();
         await threadChannel.send("Planner produced no output; aborting before implementation.");
-        await cleanupFailedWorktree();
+        await sendPreservedWorktreeNotice();
         this.logger.error({ requestId: input.requestId, durationMs: Date.now() - startedAt }, "Plan request failed with empty planner output");
         return;
       }
@@ -3637,9 +3627,7 @@ Output the result of the command or the link to the created issue.`;
       const message = this.describeExecutionError(error);
       if (threadChannel && threadChannel.isThread()) {
         await threadChannel.send(`**Plan request failed during ${stage}**\n\n${clipForDiscord(message, DISCORD_MESSAGE_LIMIT - 60)}`);
-      }
-      if (stage !== "iterative-loop") {
-        await cleanupFailedWorktree();
+        await sendPreservedWorktreeNotice();
       }
       this.logger.error({ error, requestId: input.requestId, durationMs: Date.now() - startedAt, stage }, "Plan request failed");
     }

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -3402,7 +3402,14 @@ Output the result of the command or the link to the created issue.`;
         return;
       }
 
-      await threadChannel.send(`The request branch \`${branchName}\` remains attached. Send a follow-up message or run \`/revise\` to continue; use \`/delete\` if you want to remove it.`);
+      try {
+        await threadChannel.send(`The request branch \`${branchName}\` remains attached. Send a follow-up message or run \`/revise\` to continue; use \`/delete\` if you want to remove it.`);
+      } catch (error) {
+        this.logger.warn(
+          { error, requestId: input.requestId, worktreePath, branchName },
+          "Failed to send preserved worktree notice"
+        );
+      }
     };
 
     try {

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -74,7 +74,7 @@ export const commandBuilders = [
     .setDescription("Plan with a deep model, implement with a flash model, then stop for review.")
     .addStringOption((option) => option.setName("prompt").setDescription("Request text for the plan-and-implement thread.").setRequired(true))
     .addBooleanOption((option) =>
-      option.setName("iterative").setDescription("Break the plan into iterative tasks with per-task verification.").setRequired(false)
+      option.setName("iterative").setDescription("Iterative per-task implementation and verification. Defaults true; set false for single-shot.").setRequired(false)
     ),
   new SlashCommandBuilder()
     .setName("install")

--- a/src/discord/messageTemplates.ts
+++ b/src/discord/messageTemplates.ts
@@ -8,7 +8,7 @@ export function buildHelpText(): string {
     "- `/repos` List connected repos and their channels.",
     "- `/issues [mode:<list|summary|detail>] [issue:<number>]` Read open GitHub issues for the connected repo.",
     "- `/ask prompt:<text>` Create a new request thread and run AI in an isolated worktree.",
-    "- `/plan prompt:<text> [iterative:true]` Create a request thread, run a planner, then run an implementer (with `iterative`, breaks into per-task implementation and verification).",
+    "- `/plan prompt:<text> [iterative:false]` Create a request thread, run a planner, then run iterative per-task implementation and verification by default.",
     "- `/install [package:<allowed-package-id>] [apt-package:<deb-specs>] scope:<repo|request>` Install an allowlisted tool or apt package (admin only; specify exactly one of `package` or `apt-package`).",
     "- `/review` Run adversarial code review on the current request worktree, including staged, unstaged, and untracked changes. Auto-commits any pending work before diffing (request owner or Manage Server).",
     "- `/revise [findings:<text>]` Re-run planner-verified implementation on the current request thread. Findings can be provided explicitly or will be pulled from the latest review summary (request owner or Manage Server).",

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -537,6 +537,44 @@ describe("ActuariusBot thread follow-ups", () => {
     expect(enqueue).toHaveBeenCalledTimes(1);
   });
 
+  it("replies when the latest failed request has no workspace to continue", async () => {
+    const createRequest = vi.fn();
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const bot = createBot({
+      createRequest,
+      getLatestRequestWithWorkspaceByThreadId: vi.fn().mockReturnValue(undefined),
+      getRequestByThreadId: vi.fn().mockReturnValue({
+        id: 872,
+        repo_id: 1,
+        channel_id: "channel-1",
+        thread_id: "thread-1",
+        user_id: "user-1",
+        prompt: "failed plan",
+        status: "failed",
+        worktree_path: null,
+        branch_name: null
+      })
+    });
+
+    const enqueue = vi.fn();
+    (bot as any).requestQueue.enqueue = enqueue;
+
+    await (bot as any).handleThreadMessage({
+      author: { bot: false, id: "user-1" },
+      guildId: "guild-1",
+      guild: { id: "guild-1" },
+      channelId: "thread-1",
+      channel: { isThread: () => true, parentId: "channel-1" },
+      content: "can you continue?",
+      reply,
+      attachments: { size: 0, values: () => [] }
+    });
+
+    expect(reply).toHaveBeenCalledWith(expect.stringContaining("no tracked worktree"));
+    expect(createRequest).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
   it("enqueues a request for attachment-only follow-up messages with fallback prompt", async () => {
     const createRequest = vi.fn().mockReturnValue({ id: 88 });
     const bot = createBot({
@@ -3108,12 +3146,68 @@ describe("ActuariusBot pr command", () => {
   });
 });
 
+describe("ActuariusBot plan command", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("defaults /plan to iterative execution when the option is omitted", async () => {
+    const createRequest = vi.fn().mockReturnValue({ id: 120 });
+    const bot = createBot({
+      createRequest,
+      getRepoByChannelId: vi.fn().mockReturnValue({
+        id: 5,
+        owner: "octocat",
+        repo: "hello-world",
+        full_name: "octocat/hello-world",
+        channel_id: "channel-1"
+      })
+    });
+    const enqueue = vi.fn();
+    const runPlanRequest = vi.fn().mockResolvedValue(undefined);
+    (bot as any).requestQueue.enqueue = enqueue;
+    (bot as any).runPlanRequest = runPlanRequest;
+
+    const thread = {
+      id: "thread-plan-1",
+      send: vi.fn().mockResolvedValue(undefined)
+    };
+    const seedMessage = {
+      startThread: vi.fn().mockResolvedValue(thread)
+    };
+    const repoChannel = {
+      type: ChannelType.GuildText,
+      send: vi.fn().mockResolvedValue(seedMessage)
+    };
+    const interaction = createInteraction({
+      channelId: "channel-1",
+      channel: { isThread: () => false },
+      user: { id: "user-1", tag: "user#0001" },
+      guild: {
+        id: "guild-1",
+        name: "Guild",
+        channels: { fetch: vi.fn().mockResolvedValue(repoChannel) }
+      },
+      options: {
+        getString: vi.fn().mockReturnValue("Do the thing"),
+        getBoolean: vi.fn().mockReturnValue(null)
+      }
+    });
+
+    await (bot as any).handlePlan(interaction);
+    await enqueue.mock.calls[0]![1]();
+
+    expect(interaction.editReply).toHaveBeenCalledWith(expect.stringContaining("(iterative)"));
+    expect(runPlanRequest).toHaveBeenCalledWith(expect.objectContaining({ iterative: true }));
+  });
+});
+
 describe("ActuariusBot plan runner", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it("deletes the request worktree when plan execution fails after creation", async () => {
+  it("preserves the request worktree when single-shot implementation fails after creation", async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const updateRequestStatus = vi.fn();
     const updateRequestWorkspace = vi.fn();
@@ -3136,7 +3230,9 @@ describe("ActuariusBot plan runner", () => {
       packages: [],
       env: {}
     });
-    (bot as any).runProviderText = vi.fn().mockRejectedValue(new Error("planner failed"));
+    (bot as any).runProviderText = vi.fn()
+      .mockResolvedValueOnce("plan text")
+      .mockRejectedValueOnce(new Error("implementer failed"));
 
     await (bot as any).runPlanRequest({
       requestId: 91,
@@ -3149,25 +3245,16 @@ describe("ActuariusBot plan runner", () => {
       },
       prompt: "Do the thing",
       planner: { provider: "claude" },
-      implementer: { provider: "claude" }
+      implementer: { provider: "claude" },
+      iterative: false
     });
 
     expect(updateRequestStatus).toHaveBeenCalledWith(91, "failed");
-    expect(deleteRequestBranch).toHaveBeenCalledWith(
-      "/data/repos",
-      {
-        owner: "octocat",
-        repo: "hello-world",
-        fullName: "octocat/hello-world"
-      },
-      {
-        branchName: "ask/91-123",
-        worktreePath: "/tmp/worktree-plan"
-      }
-    );
-    expect(updateRequestWorkspace).toHaveBeenNthCalledWith(1, 91, "/tmp/worktree-plan", "ask/91-123");
-    expect(updateRequestWorkspace).toHaveBeenNthCalledWith(2, 91, null, null);
-    expect(send).toHaveBeenCalledWith(expect.stringContaining("Plan request failed during planning"));
+    expect(deleteRequestBranch).not.toHaveBeenCalled();
+    expect(updateRequestWorkspace).toHaveBeenCalledTimes(1);
+    expect(updateRequestWorkspace).toHaveBeenCalledWith(91, "/tmp/worktree-plan", "ask/91-123");
+    expect(send).toHaveBeenCalledWith(expect.stringContaining("Plan request failed during implementing"));
+    expect(send).toHaveBeenCalledWith(expect.stringContaining("remains attached"));
   });
 
   it("preserves worktree when iterative loop fails so /revise can continue", async () => {
@@ -3663,7 +3750,7 @@ describe("ActuariusBot plan runner", () => {
     expect(updateRequestStatus).toHaveBeenCalledWith(95, "succeeded");
   });
 
-  it("planner/implementer errors mark failed and clean up worktree", async () => {
+  it("preserves worktree when planner errors after worktree creation", async () => {
     vi.mocked(ensureRepoCheckedOutToMaster).mockResolvedValue({ localPath: "/tmp/repo" });
     vi.mocked(createRequestWorktree).mockResolvedValue({
       path: "/tmp/worktree-plan",
@@ -3696,8 +3783,11 @@ describe("ActuariusBot plan runner", () => {
     });
 
     expect(updateRequestStatus).toHaveBeenCalledWith(96, "failed");
-    expect(deleteRequestBranch).toHaveBeenCalled();
+    expect(deleteRequestBranch).not.toHaveBeenCalled();
+    expect(updateRequestWorkspace).toHaveBeenCalledTimes(1);
+    expect(updateRequestWorkspace).toHaveBeenCalledWith(96, "/tmp/worktree-plan", "ask/96-123");
     expect(send).toHaveBeenCalledWith(expect.stringContaining("Plan request failed during planning"));
+    expect(send).toHaveBeenCalledWith(expect.stringContaining("remains attached"));
   });
 });
 

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -3257,6 +3257,67 @@ describe("ActuariusBot plan runner", () => {
     expect(send).toHaveBeenCalledWith(expect.stringContaining("remains attached"));
   });
 
+  it("does not mask the plan failure when the preserved worktree notice cannot be sent", async () => {
+    const noticeError = new Error("thread archived");
+    const send = vi.fn().mockImplementation(async (content: string) => {
+      if (content.includes("remains attached")) {
+        throw noticeError;
+      }
+    });
+    const updateRequestStatus = vi.fn();
+    const updateRequestWorkspace = vi.fn();
+    const warn = vi.spyOn(logger, "warn");
+    const bot = createBot({
+      updateRequestStatus,
+      updateRequestWorkspace
+    });
+
+    vi.mocked(ensureRepoCheckedOutToMaster).mockResolvedValue({ localPath: "/tmp/repo" });
+    vi.mocked(createRequestWorktree).mockResolvedValue({
+      path: "/tmp/worktree-plan",
+      branchName: "ask/95-123"
+    });
+    (bot as any).client.channels.fetch = vi.fn().mockResolvedValue({
+      isThread: () => true,
+      send
+    });
+    (bot as any).installService.buildMinimalExecutionEnvironment = vi.fn().mockReturnValue({
+      packages: [],
+      env: {}
+    });
+    (bot as any).runProviderText = vi.fn()
+      .mockResolvedValueOnce("plan text")
+      .mockRejectedValueOnce(new Error("implementer failed"));
+
+    await expect((bot as any).runPlanRequest({
+      requestId: 95,
+      threadId: "thread-1",
+      repoId: 5,
+      repo: {
+        owner: "octocat",
+        repo: "hello-world",
+        fullName: "octocat/hello-world"
+      },
+      prompt: "Do the thing",
+      planner: { provider: "claude" },
+      implementer: { provider: "claude" },
+      iterative: false
+    })).resolves.toBeUndefined();
+
+    expect(updateRequestStatus).toHaveBeenCalledWith(95, "failed");
+    expect(updateRequestWorkspace).toHaveBeenCalledWith(95, "/tmp/worktree-plan", "ask/95-123");
+    expect(warn).toHaveBeenCalledWith(
+      {
+        error: noticeError,
+        requestId: 95,
+        worktreePath: "/tmp/worktree-plan",
+        branchName: "ask/95-123"
+      },
+      "Failed to send preserved worktree notice"
+    );
+    warn.mockRestore();
+  });
+
   it("preserves worktree when iterative loop fails so /revise can continue", async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const updateRequestStatus = vi.fn();


### PR DESCRIPTION
## Summary

- Preserve `/plan` worktree and branch metadata when planner or implementer execution fails after worktree creation.
- Reply visibly in failed request threads when no tracked workspace remains to continue from.
- Make `/plan` default to iterative execution, with `iterative:false` still available for single-shot mode.

Closes #149.

## Validation

- `npm test -- tests/botCommands.test.ts`
- `npm test -- tests/commands.test.ts`
- `npm run check`
- `npm run build`
- `git diff --check`

Full `npm test` was also run. It still fails on existing Windows-host issues outside this change: attachment prompt path separators, shell-script harness exit 127/null status in `seedProviderClis`, `installLlmUserInstructions`, and `redeployScript` tests.