### PR TITLE
[codex] fix iterative plan JSON recovery

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -212,11 +212,21 @@ const ITERATIVE_OVERVIEW_LIMIT = 2_000;
 
 export function stripMarkdownJsonFence(text: string): string {
   const trimmed = text.trim();
-  const jsonMatch = /```(?:json)?[^\S\r\n]*\r?\n?([\s\S]*?)\r?\n?```/iu.exec(trimmed);
-  if (jsonMatch?.[1]) {
-    return jsonMatch[1].trim();
+  const lines = trimmed.split(/\r?\n/u);
+  const openingFenceIndex = lines.findIndex((line) => /^[\t ]*```(?:json)?[\t ]*$/iu.test(line));
+  if (openingFenceIndex < 0) {
+    return trimmed;
   }
-  return trimmed;
+
+  const closingFenceOffset = lines
+    .slice(openingFenceIndex + 1)
+    .findIndex((line) => /^[\t ]*```[\t ]*$/u.test(line));
+  if (closingFenceOffset < 0) {
+    return trimmed;
+  }
+
+  const closingFenceIndex = openingFenceIndex + closingFenceOffset + 1;
+  return lines.slice(openingFenceIndex + 1, closingFenceIndex).join("\n").trim();
 }
 
 function truncateText(text: string, limit: number): string {
@@ -227,33 +237,97 @@ function truncateText(text: string, limit: number): string {
   return `${normalized.slice(0, limit - 3).trimEnd()}...`;
 }
 
-export function parseIterativePlan(text: string): { overview: string; tasks: IterativePlanTask[] } | null {
-  const stripped = stripMarkdownJsonFence(text);
+function normalizeIterativePlan(parsed: unknown): { overview: string; tasks: IterativePlanTask[] } | null {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const candidate = parsed as { overview?: unknown; tasks?: unknown };
+  if (typeof candidate.overview !== "string" || candidate.overview.trim().length === 0 || !Array.isArray(candidate.tasks) || candidate.tasks.length === 0) {
+    return null;
+  }
+  const tasks = candidate.tasks.flatMap((task) => {
+    if (!task || typeof task.title !== "string" || typeof task.description !== "string") {
+      return [];
+    }
+    const title = truncateText(task.title.replace(/\s+/g, " "), ITERATIVE_TASK_TITLE_LIMIT);
+    const description = truncateText(task.description, ITERATIVE_TASK_DESCRIPTION_LIMIT);
+    if (!title || !description) {
+      return [];
+    }
+    return [{ title, description }];
+  });
+  if (tasks.length === 0) return null;
+  return { overview: truncateText(candidate.overview, ITERATIVE_OVERVIEW_LIMIT), tasks };
+}
+
+function parseIterativePlanCandidate(text: string): { overview: string; tasks: IterativePlanTask[] } | null {
   try {
-    const parsed = JSON.parse(stripped) as unknown;
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
-    }
-    const candidate = parsed as { overview?: unknown; tasks?: unknown };
-    if (typeof candidate.overview !== "string" || candidate.overview.trim().length === 0 || !Array.isArray(candidate.tasks) || candidate.tasks.length === 0) {
-      return null;
-    }
-    const tasks = candidate.tasks.flatMap((task) => {
-      if (!task || typeof task.title !== "string" || typeof task.description !== "string") {
-        return [];
-      }
-      const title = truncateText(task.title.replace(/\s+/g, " "), ITERATIVE_TASK_TITLE_LIMIT);
-      const description = truncateText(task.description, ITERATIVE_TASK_DESCRIPTION_LIMIT);
-      if (!title || !description) {
-        return [];
-      }
-      return [{ title, description }];
-    });
-    if (tasks.length === 0) return null;
-    return { overview: truncateText(candidate.overview, ITERATIVE_OVERVIEW_LIMIT), tasks };
+    return normalizeIterativePlan(JSON.parse(text) as unknown);
   } catch {
     return null;
   }
+}
+
+function extractBalancedJsonObject(text: string, startIndex: number): string | null {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = startIndex; index < text.length; index++) {
+    const character = text[index]!;
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === "\"") {
+      inString = true;
+    } else if (character === "{") {
+      depth++;
+    } else if (character === "}") {
+      depth--;
+      if (depth === 0) {
+        return text.slice(startIndex, index + 1);
+      }
+      if (depth < 0) {
+        return null;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function parseIterativePlan(text: string): { overview: string; tasks: IterativePlanTask[] } | null {
+  const trimmed = text.trim();
+  const stripped = stripMarkdownJsonFence(trimmed);
+  const directCandidates = stripped === trimmed ? [trimmed] : [trimmed, stripped];
+
+  for (const candidate of directCandidates) {
+    const parsed = parseIterativePlanCandidate(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  for (let startIndex = trimmed.indexOf("{"); startIndex >= 0; startIndex = trimmed.indexOf("{", startIndex + 1)) {
+    const candidate = extractBalancedJsonObject(trimmed, startIndex);
+    if (!candidate) {
+      continue;
+    }
+    const parsed = parseIterativePlanCandidate(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  return null;
 }
 
 function splitPlainTextForDiscord(text: string, header?: string): string[] {

--- a/tests/iterativePlanParser.test.ts
+++ b/tests/iterativePlanParser.test.ts
@@ -46,6 +46,63 @@ describe("iterative plan parsing", () => {
     });
   });
 
+  it("does not treat triple backticks inside JSON strings as an outer fence", () => {
+    const text = JSON.stringify({
+      overview: "Fix Markdown handling",
+      tasks: [{
+        title: "Escape fences",
+        description: "Replace /```/gu and preserve the closing ``` marker"
+      }]
+    });
+
+    expect(stripMarkdownJsonFence(text)).toBe(text);
+    expect(parseIterativePlan(text)).toEqual({
+      overview: "Fix Markdown handling",
+      tasks: [{
+        title: "Escape fences",
+        description: "Replace /```/gu and preserve the closing ``` marker"
+      }]
+    });
+  });
+
+  it("parses fenced JSON containing triple backticks in string values", () => {
+    const plan = JSON.stringify({
+      overview: "Fix Markdown handling",
+      tasks: [{
+        title: "Escape fences",
+        description: "Ensure ``` inside a description does not close the outer fence"
+      }]
+    }, null, 2);
+    const text = `Here is the plan:\n\`\`\`json\n${plan}\n\`\`\`\nTrailing note.`;
+
+    expect(parseIterativePlan(text)).toEqual({
+      overview: "Fix Markdown handling",
+      tasks: [{
+        title: "Escape fences",
+        description: "Ensure ``` inside a description does not close the outer fence"
+      }]
+    });
+  });
+
+  it("extracts a balanced plan object from surrounding prose", () => {
+    const plan = JSON.stringify({
+      overview: "Fix parser recovery",
+      tasks: [{
+        title: "Extract JSON",
+        description: "Ignore prose and braces like {this} inside JSON strings"
+      }]
+    }, null, 2);
+    const text = `I have enough context to produce the plan.\n\n${plan}\n\`\`\`\nDone.`;
+
+    expect(parseIterativePlan(text)).toEqual({
+      overview: "Fix parser recovery",
+      tasks: [{
+        title: "Extract JSON",
+        description: "Ignore prose and braces like {this} inside JSON strings"
+      }]
+    });
+  });
+
   it("returns null for non-object JSON primitives", () => {
     expect(parseIterativePlan("null")).toBeNull();
     expect(parseIterativePlan("\"hello\"")).toBeNull();

--- a/tests/iterativePlanParser.test.ts
+++ b/tests/iterativePlanParser.test.ts
@@ -84,6 +84,24 @@ describe("iterative plan parsing", () => {
     });
   });
 
+  it("parses fenced JSON with CRLF line endings", () => {
+    const text = [
+      "```json",
+      "{",
+      '  "overview": "Plan",',
+      '  "tasks": [',
+      '    { "title": "Task", "description": "Do it" }',
+      "  ]",
+      "}",
+      "```"
+    ].join("\r\n");
+
+    expect(parseIterativePlan(text)).toEqual({
+      overview: "Plan",
+      tasks: [{ title: "Task", description: "Do it" }]
+    });
+  });
+
   it("extracts a balanced plan object from surrounding prose", () => {
     const plan = JSON.stringify({
       overview: "Fix parser recovery",


### PR DESCRIPTION
## Summary

- parse the complete planner response before attempting Markdown-fence recovery
- only treat standalone fence-delimiter lines as an outer JSON fence
- recover a balanced top-level JSON object from surrounding planner prose while respecting quoted strings and escapes
- add regressions for triple backticks inside task descriptions, fenced JSON containing backticks, and prose-wrapped plans

## Root cause

`stripMarkdownJsonFence` used an unanchored regex. When a valid plan mentioned triple-backtick syntax inside a task description, the regex treated those in-string backticks as an outer Markdown wrapper, extracted the text between them, and passed that fragment to `JSON.parse`. Planner responses with leading prose also had no recovery path unless the regex happened to identify a fence.

## Impact

`/plan` and `/revise` can continue iterative execution with the planner's actual task list instead of falling back to one task containing the entire planner output.

## Validation

- `npm test -- tests/iterativePlanParser.test.ts` — 12/12 passed
- `npm run check` — passed
- `npm run build` — passed
- `npm test` — 513 passed, 12 failed in the existing Windows shell-script harnesses (`seedProviderClis`, `installLlmUserInstructions`, and `redeployScript`); these failures are unrelated to the changed files