### PR TITLE
fix: publish MemPalace federation port on VM loopback in redeploy

### DIFF
--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -107,7 +107,9 @@ if [ "$ENABLE_MEMPALACE_REMOTE" = "true" ]; then
   # Publish the federation server on the VM's loopback only. Remote access
   # goes through an IAP SSH tunnel; the port is never exposed publicly.
   REMOTE_PORT="${MEMPALACE_REMOTE_BIND##*:}"
-  REMOTE_PORT="${REMOTE_PORT:-8765}"
+  case "$REMOTE_PORT" in
+    ''|*[!0-9]*) REMOTE_PORT="8765" ;;
+  esac
   EXTRA_ARGS+=(-p "127.0.0.1:$REMOTE_PORT:$REMOTE_PORT")
 fi
 if [ -n "$MEMPALACE_REMOTE_URL" ]; then

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -104,6 +104,11 @@ fi
 if [ "$ENABLE_MEMPALACE_REMOTE" = "true" ]; then
   EXTRA_ARGS+=(-e "MEMPALACE_ENABLED=true")
   EXTRA_ARGS+=(-e "MEMPALACE_REMOTE_ENABLED=true")
+  # Publish the federation server on the VM's loopback only. Remote access
+  # goes through an IAP SSH tunnel; the port is never exposed publicly.
+  REMOTE_PORT="${MEMPALACE_REMOTE_BIND##*:}"
+  REMOTE_PORT="${REMOTE_PORT:-8765}"
+  EXTRA_ARGS+=(-p "127.0.0.1:$REMOTE_PORT:$REMOTE_PORT")
 fi
 if [ -n "$MEMPALACE_REMOTE_URL" ]; then
   EXTRA_ARGS+=(-e "MEMPALACE_REMOTE_URL=$MEMPALACE_REMOTE_URL")

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -110,6 +110,10 @@ if [ "$ENABLE_MEMPALACE_REMOTE" = "true" ]; then
   case "$REMOTE_PORT" in
     ''|*[!0-9]*) REMOTE_PORT="8765" ;;
   esac
+  # The in-container server must listen on all container interfaces for the
+  # published port to reach it; a container-loopback bind is unreachable from
+  # docker-proxy. Host exposure is still governed by the 127.0.0.1 publish.
+  MEMPALACE_REMOTE_BIND="0.0.0.0:$REMOTE_PORT"
   EXTRA_ARGS+=(-p "127.0.0.1:$REMOTE_PORT:$REMOTE_PORT")
 fi
 if [ -n "$MEMPALACE_REMOTE_URL" ]; then


### PR DESCRIPTION
## Summary

When `ENABLE_MEMPALACE_REMOTE=true`, the federation server binds inside the container but the `docker run` in `scripts/redeploy.sh` had no port publish — so the server was unreachable even from the VM host's loopback. This was the root cause of both earlier federation tunnel failures (the "connection reset" and the IAP 4003 were downstream symptoms of the same missing publish).

This adds `-p 127.0.0.1:<port>:<port>` when the remote is enabled:

- The port is derived from `MEMPALACE_REMOTE_BIND` (everything after the last `:`), defaulting to `8765`.
- The publish is bound to the VM's loopback only — remote access still requires an IAP-authenticated SSH tunnel, and nothing is exposed publicly. No firewall changes needed.

Pairs with `mempalace_remote_bind = "0.0.0.0:8765"` in terraform.tfvars (the server must listen on the container's eth0 for docker-proxy to reach it).

## Verification

Already running in production: this exact change was deployed to the VM on 2026-07-02 and verified end-to-end — VM-loopback health 200, tunneled local health 200, authenticated `/v1/changes` 200, and a federated drawer write round-trip. This PR brings the repo in line with what's deployed.

Local `tests/redeployScript.test.ts` fails on Windows hosts with the known pre-existing exit-127 harness issue (all shell-script suites); relying on CI for the real signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)