### PR TITLE
chore: ignore terraform plan files and local request worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,11 @@ infra/terraform.tfstate
 infra/terraform.tfstate.backup
 infra/.terraform.lock.hcl
 infra/*.backup
+infra/tfplan
+infra/*.tfplan
+
+# Request worktrees from local bot runs
+.worktrees/
 
 # MemPalace
 mempalace.yaml


### PR DESCRIPTION
## Summary

- Ignore `infra/tfplan` / `infra/*.tfplan` — binary Terraform plan files can embed variable values (including sensitive ones) and should never be committed. One was sitting untracked in the working tree after a recent `terraform plan -out`.
- Ignore `.worktrees/` — request worktrees created by local bot runs (`docker-compose` testing) land in the repo root and shouldn't be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)