### PR TITLE
chore: commit mempalace.yaml so bot worktrees use the human wing name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ infra/*.tfplan
 
 # Request worktrees from local bot runs
 .worktrees/
-
-# MemPalace
-mempalace.yaml

--- a/mempalace.yaml
+++ b/mempalace.yaml
@@ -1,0 +1,82 @@
+wing: wing_actuarius
+rooms:
+- name: .claude
+  description: Files from .claude/
+  keywords:
+  - .claude
+  - .claude
+- name: .github
+  description: Files from .github/
+  keywords:
+  - .github
+  - .github
+- name: .terraform
+  description: Files from .terraform/
+  keywords:
+  - .terraform
+  - .terraform
+- name: backend
+  description: Files from db, services/
+  keywords:
+  - backend
+  - db
+  - services
+- name: configuration
+  description: Files from infra/
+  keywords:
+  - configuration
+  - infra
+- name: discord
+  description: Files from discord/
+  keywords:
+  - discord
+  - discord
+- name: docker
+  description: Files from docker/
+  keywords:
+  - docker
+  - docker
+- name: documentation
+  description: Files from docs/
+  keywords:
+  - documentation
+  - docs
+- name: general
+  description: Files that don't fit other rooms
+  keywords: []
+- name: llm_user_instructions
+  description: Files from llm-user-instructions/
+  keywords:
+  - llm_user_instructions
+  - llm-user-instructions
+- name: reviews
+  description: Files from reviews/
+  keywords:
+  - reviews
+  - reviews
+- name: scripts
+  description: Files from scripts, utils/
+  keywords:
+  - scripts
+  - scripts
+  - utils
+- name: src
+  description: Files from src/
+  keywords:
+  - src
+  - src
+- name: testing
+  description: Files from tests/
+  keywords:
+  - testing
+  - tests
+- name: todo
+  description: Files from todo/
+  keywords:
+  - todo
+  - todo
+- name: workflows
+  description: Files from workflows/
+  keywords:
+  - workflows
+  - workflows


### PR DESCRIPTION
## Summary

The bot resolves a repo's memory wing from `mempalace.yaml` in the checkout, falling back to a collision-proof hashed name (`wing_repo_digitumdei_actuarius_5936a0ce`) when the file is absent. Because the file was gitignored, it was absent from every request worktree, so the bot has been writing all repo memories to the hashed wing forever.

This commits the existing `mempalace-cli init`-generated config (`wing: wing_actuarius` + repo-structure-derived rooms) and removes the gitignore entry:

- Every request worktree now materializes the tracked file, so `ensureWorktreeConfig` reads `wing_actuarius` instead of generating the hashed fallback.
- Bot memories land in a wing that merges by name with local palaces under MemPalace federation combined-mode reads.
- The bot only parses `wing:` from this file; routing is still wired by the bot into the container config, so no `routing:` section is needed here.

The old hashed wing (15 mined drawers) goes stale but is derived data that will re-mine into `wing_actuarius`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)