### PR TITLE
fix: prune stale bot-managed wing rules and checkouts from global config

### DIFF
--- a/src/services/memPalaceRemoteService.ts
+++ b/src/services/memPalaceRemoteService.ts
@@ -407,6 +407,21 @@ export class MemPalaceRemoteService {
     await write;
   }
 
+  /**
+   * True when a wing rule has exactly the shape this service writes, and can
+   * therefore be safely dropped once its wing is no longer tracked. Anything
+   * else is treated as operator-authored and preserved.
+   */
+  private isManagedWingRule(rule: unknown): boolean {
+    return (
+      isRecord(rule) &&
+      rule.mode === "combined" &&
+      rule.remote === this.config.mempalaceRemoteName &&
+      rule.write === "remote" &&
+      Object.keys(rule).length === 3
+    );
+  }
+
   private async writeGlobalConfigOnce(): Promise<void> {
     await this.ensureToken();
     const configDir = join(this.homeDir, ".mempalace");
@@ -415,8 +430,10 @@ export class MemPalaceRemoteService {
     const current = await readJsonObject(configPath);
 
     const server = isRecord(current.server) ? { ...current.server } : {};
-    const existingCheckouts = isRecord(server.checkouts) ? server.checkouts : {};
-    const checkouts: Record<string, string> = { ...existingCheckouts } as Record<string, string>;
+    // server.checkouts is wholly bot-managed: rebuild rather than merge, so
+    // entries for wings we no longer track (renames, disconnected repos)
+    // don't accumulate forever.
+    const checkouts: Record<string, string> = {};
     for (const [wing, checkoutPath] of this.repoCheckouts.entries()) checkouts[wing] = checkoutPath;
 
     const federation = isRecord(current.federation) ? { ...current.federation } : {};
@@ -429,8 +446,14 @@ export class MemPalaceRemoteService {
       timeout_ms: this.config.mempalaceRemoteTimeoutMs
     });
 
+    // Keep operator-authored wing rules, but drop bot-managed rules for wings
+    // we no longer track — each stale rule is a live combined-mode route to a
+    // wing that will never receive new content.
     const existingWings = isRecord(federation.wings) ? federation.wings : {};
-    const wings: Record<string, unknown> = { ...existingWings };
+    const wings: Record<string, unknown> = {};
+    for (const [wing, rule] of Object.entries(existingWings)) {
+      if (!this.isManagedWingRule(rule)) wings[wing] = rule;
+    }
     for (const wing of this.repoCheckouts.keys()) {
       wings[wing] = { mode: "combined", remote: this.config.mempalaceRemoteName, write: "remote" };
     }

--- a/tests/memPalaceRemoteService.test.ts
+++ b/tests/memPalaceRemoteService.test.ts
@@ -152,6 +152,47 @@ describe("MemPalaceRemoteService", () => {
     expect(readFileSync(join(checkoutPath, ".git", "info", "exclude"), "utf8")).toContain("mempalace.yaml");
   });
 
+  it("prunes stale bot-managed wing rules and checkouts, preserving operator-authored rules", async () => {
+    const root = mkdtempSync(join(tmpdir(), "actuarius-mempalace-prune-"));
+    const homeDir = join(root, "home");
+    const config = makeConfig(root);
+    const repo = makeRepo();
+    const checkoutPath = join(config.reposRootPath, repo.owner, repo.repo);
+    mkdirSync(join(checkoutPath, ".git", "info"), { recursive: true });
+    mkdirSync(join(homeDir, ".mempalace"), { recursive: true });
+    writeFileSync(
+      join(homeDir, ".mempalace", "config.json"),
+      JSON.stringify({
+        server: {
+          checkouts: {
+            wing_repo_digitumdei_actuarius_5936a0ce: "/data/repos/digitumdei/actuarius"
+          }
+        },
+        federation: {
+          wings: {
+            // Stale bot-managed rule from the old hashed naming — must be dropped.
+            wing_repo_digitumdei_actuarius_5936a0ce: { mode: "combined", remote: "actuarius", write: "remote" },
+            // Operator-authored rules — must survive (different shape / extra keys).
+            wing_custom: { mode: "local" },
+            wing_tuned: { mode: "combined", remote: "actuarius", write: "remote", note: "keep me" }
+          }
+        }
+      }),
+      "utf8"
+    );
+
+    const service = new MemPalaceRemoteService(config, logger, { homeDir });
+    const wing = await service.registerRepository(repo, checkoutPath);
+
+    const globalConfig = JSON.parse(readFileSync(join(homeDir, ".mempalace", "config.json"), "utf8"));
+    expect(globalConfig.federation.wings).toEqual({
+      wing_custom: { mode: "local" },
+      wing_tuned: { mode: "combined", remote: "actuarius", write: "remote", note: "keep me" },
+      [wing]: { mode: "combined", remote: "actuarius", write: "remote" }
+    });
+    expect(globalConfig.server.checkouts).toEqual({ [wing]: checkoutPath });
+  });
+
   it("preserves an operator-authored kg routing rule", async () => {
     const root = mkdtempSync(join(tmpdir(), "actuarius-mempalace-kg-"));
     const homeDir = join(root, "home");


### PR DESCRIPTION
## Summary

`writeGlobalConfig` merged existing `federation.wings` and `server.checkouts` entries and only ever added, so entries for wings the bot no longer tracks accumulated forever. The live VM config currently carries ten wing rules where five belong — the pre-#167 hashed names (`wing_repo_digitumdei_*_<digest>`) alongside the new human-named wings. Each stale rule is a live combined-mode route: searches touching those wings still fan out to the remote for a wing that will never receive new content.

### Changes

- **`server.checkouts`**: wholly bot-managed, so it is rebuilt from the current checkout map instead of merged.
- **`federation.wings`**: bot-shaped rules (`{mode: combined, remote: <name>, write: remote}`, exactly three keys) for wings no longer tracked are dropped. Anything else — a different mode, a different remote, extra keys — is treated as operator-authored and preserved.

### Rollout

On the first startup after deploy, the five stale hashed rules and their checkout entries disappear from the container config. The stale mined data in the remote palace (15 drawers under the old hashed wing) is untouched — it just stops being routed to.

## Verification

- `npm run check`, `npm run build` pass.
- New test: a config pre-populated with a stale managed rule + checkout, a hand-authored `{mode: local}` rule, and a managed-shaped rule with an extra key — after registration only the stale managed entry is gone. 14/14 suite tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)