### PR TITLE
feat: move all secret values to Google Secret Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Every push to `main` builds and pushes two image tags to ghcr.io:
 - `ghcr.io/digitumdei/actuarius:latest`
 - `ghcr.io/digitumdei/actuarius:<git-sha>`
 
-Infrastructure is managed via Terraform (`infra/`). VM instance metadata is the source of truth for env vars and the redeploy script itself.
+Infrastructure is managed via Terraform (`infra/`). VM instance metadata is the source of truth for non-secret env vars and the redeploy script itself; secret values live in Google Secret Manager and are added out-of-band with `gcloud secrets versions add` — they never appear in `terraform.tfvars`, state, or metadata (see [docs/deploy.md](docs/deploy.md)).
 
 ### Deploy latest image or roll back
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -21,7 +21,27 @@ cd infra
 terraform apply
 ```
 
-This writes all configuration into [instance metadata](https://cloud.google.com/compute/docs/metadata) — environment variables, secrets, and the redeploy script itself (`env-redeploy-script`). **It does not restart the VM or the container.**
+This writes all **non-secret** configuration into [instance metadata](https://cloud.google.com/compute/docs/metadata) — environment variables and the redeploy script itself (`env-redeploy-script`) — and creates empty [Secret Manager](https://cloud.google.com/secret-manager) containers for the secret values (see below). **It does not restart the VM or the container.**
+
+## Secrets
+
+Secret values (Discord token, GitHub App private key, Claude OAuth token, API
+keys, MemPalace federation token) never pass through Terraform: not in
+`terraform.tfvars`, not in state, not in saved plan files, not in VM metadata.
+Terraform only creates the secret *containers* (`infra/secrets.tf`) and grants
+the VM service account `roles/secretmanager.secretAccessor`. Add or rotate
+values with:
+
+```bash
+gcloud secrets versions add actuarius-discord-token --data-file=-   # paste value, then Ctrl+D
+```
+
+Secret names: `actuarius-discord-token`, `actuarius-claude-oauth-token`,
+`actuarius-github-app-private-key-b64` (or `actuarius-github-app-private-key`
+for a raw PEM — set only one), `actuarius-gh-token`, `actuarius-gemini-api-key`,
+`actuarius-mempalace-remote-token`. `redeploy.sh` always reads
+`versions/latest`, so rotation is: add a new version, run redeploy. Never pass
+secrets as command-line arguments — they end up in shell history and `ps`.
 
 ## Redeploy
 
@@ -48,7 +68,7 @@ sudo reboot
 
 ## What redeploy.sh does
 
-1. Reads metadata env vars (`env-discord-token`, `env-enable-codex-execution`, `env-enable-opencode-execution`, etc.)
+1. Reads non-secret config from metadata (`env-discord-client-id`, `env-enable-codex-execution`, etc.) and secret values from Secret Manager (`actuarius-discord-token`, etc.) using the VM service account's access token
 2. Pulls the Docker image (`ghcr.io/digitumdei/actuarius:latest` or a specific SHA tag)
 3. Stops and removes the old container
 4. Starts a new container with the correct env vars mapped from metadata
@@ -79,7 +99,7 @@ After `terraform apply`, reboot or re-fetch `/var/redeploy.sh` from metadata so 
 
 ## Adding a new env var
 
-Three places need updating:
+**Non-secret config** — three places:
 
 | Step | File | What to add |
 |------|------|-------------|
@@ -87,5 +107,13 @@ Three places need updating:
 | 2. Metadata mapping | `infra/compute.tf` | New `env-<name>` metadata entry referencing the variable |
 | 3. Container env | `scripts/redeploy.sh` | `get_meta` call + `-e` flag in `EXTRA_ARGS` |
 
-After steps 1-2: run `terraform apply` to push the metadata.
-After step 3: the redeploy script must be re-fetched (reboot or manual `curl`).
+**Secret values** — never a Terraform variable:
+
+| Step | Where | What to do |
+|------|-------|------------|
+| 1. Secret container | `infra/secrets.tf` | Add the name to `local.actuarius_secrets` |
+| 2. Secret value | `gcloud` | `gcloud secrets versions add actuarius-<name> --data-file=-` |
+| 3. Container env | `scripts/redeploy.sh` | `get_secret` call + `-e` flag in `EXTRA_ARGS` |
+
+After Terraform changes: run `terraform apply` to push metadata / create containers.
+After `redeploy.sh` changes: the redeploy script must be re-fetched (reboot or manual `curl`).

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -71,3 +71,12 @@ sudo bash /var/redeploy.sh
 ## Single-guild deployment model
 
 Actuarius is one instance per Discord guild. Multi-guild from a single instance is not supported and would be a major architectural change. Do not add multi-guild abstractions or per-guild isolation for shared resources (credentials, toolchains, etc.).
+
+## Terraform plan/state files contain secrets in cleartext — never in the repo tree
+
+On 2026-07-07 a saved plan file (`terraform plan -out=...`) written into `infra/` was swept into a commit by `git add -A` and pushed to the then-public repo. Plan files embed the full prior state, including every VM metadata value — at the time that meant the Discord token, GitHub App private key, Claude OAuth token, and Gemini API key. Three independent scanners (GitHub secret scanning, Discord, Google) detected it within minutes; all credentials had to be rotated.
+
+**Rules:**
+- Never write `terraform plan -out` files, state files, or state backups inside the repo tree; use a temp/scratch directory. `.gitignore` now blocks `tfplan*` as a backstop.
+- Prefer `git add <specific files>` over `git add -A` after infra work.
+- Secret values must not pass through Terraform at all: they live in Secret Manager (`infra/secrets.tf` creates containers; values added via `gcloud secrets versions add`), so tfvars, state, and plan files stay secret-free by construction.

--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -40,15 +40,16 @@ resource "google_compute_instance" "actuarius" {
   # All config and scripts stored in metadata — the startup script is a static
   # bootstrapper that pulls the real script from metadata, so metadata changes
   # never force VM recreation.
+  # Metadata carries NON-SECRET config only. Secret values (Discord token,
+  # GitHub App key, Claude OAuth token, API keys, federation token) live in
+  # Secret Manager (see secrets.tf) and are fetched by redeploy.sh at deploy
+  # time — never through Terraform, so they cannot leak via tfvars, state, or
+  # plan files.
   metadata = {
-    env-discord-token                    = var.discord_token
     env-discord-client-id                = var.discord_client_id
     env-discord-guild-id                 = var.discord_guild_id
-    env-gh-token                         = var.gh_token
     env-github-app-id                    = var.github_app_id
     env-github-app-installation-id       = var.github_app_installation_id
-    env-github-app-private-key-b64       = var.github_app_private_key_b64
-    env-claude-oauth-token               = var.claude_oauth_token
     env-docker-image                     = var.docker_image
     env-ask-concurrency                  = var.ask_concurrency
     env-container-memory                 = var.container_memory
@@ -62,12 +63,10 @@ resource "google_compute_instance" "actuarius" {
     env-mempalace-remote-url             = var.mempalace_remote_url
     env-mempalace-remote-bind            = var.mempalace_remote_bind
     env-mempalace-remote-name            = var.mempalace_remote_name
-    env-mempalace-remote-token           = var.mempalace_remote_token
     env-mempalace-remote-timeout-ms      = var.mempalace_remote_timeout_ms
     env-mempalace-remote-mine-on-sync    = var.mempalace_remote_mine_on_sync
     env-mempalace-remote-mine-timeout-ms = var.mempalace_remote_mine_timeout_ms
     env-mempalace-remote-mine-batch-size = var.mempalace_remote_mine_batch_size
-    env-gemini-api-key                   = var.gemini_api_key
     env-redeploy-script                  = file("${path.module}/../scripts/redeploy.sh")
     env-startup-script                   = file("${path.module}/startup.sh")
   }

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -1,0 +1,39 @@
+resource "google_project_service" "secretmanager" {
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Secret CONTAINERS only — never values. Values are added out-of-band with
+# `gcloud secrets versions add <name> --data-file=-` so they never appear in
+# terraform.tfvars, Terraform state, or saved plan files (see the 2026-07-07
+# incident in docs/lessons-learned.md). scripts/redeploy.sh reads them at
+# deploy time using the VM service account's access token.
+locals {
+  actuarius_secrets = [
+    "actuarius-discord-token",
+    "actuarius-gh-token",
+    "actuarius-github-app-private-key",
+    "actuarius-github-app-private-key-b64",
+    "actuarius-claude-oauth-token",
+    "actuarius-gemini-api-key",
+    "actuarius-mempalace-remote-token",
+  ]
+}
+
+resource "google_secret_manager_secret" "actuarius" {
+  for_each  = toset(local.actuarius_secrets)
+  secret_id = each.key
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_iam_member" "bot_accessor" {
+  for_each  = google_secret_manager_secret.actuarius
+  secret_id = each.value.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.actuarius_bot.email}"
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -1,5 +1,7 @@
 # Copy this file to terraform.tfvars and fill in your values.
-# terraform.tfvars is gitignored — never commit real secrets.
+# terraform.tfvars is gitignored, but it must contain NO secrets regardless:
+# secret values live in Google Secret Manager and are added out-of-band (see
+# the "Secrets" section below and docs/deploy.md).
 
 gcp_project_id = "your-gcp-project-id"
 gcp_region     = "us-east1"
@@ -11,31 +13,34 @@ container_memory  = "700m"
 container_cpus    = "0.8"
 container_pids_limit = 256
 
-# Discord application credentials
-discord_token     = "replace_me"
+# Discord application config (IDs are not secrets; the bot token is — see below)
 discord_client_id = "replace_me"
 discord_guild_id = "replace_me"   # Optional: omit for global command registration
 
-# GitHub App auth (preferred)
+# GitHub App config (IDs are not secrets; the private key is — see below)
 github_app_id              = "replace_me"
 github_app_installation_id = "replace_me"
-github_app_private_key_b64 = "replace_me"
-
-# GitHub personal access token (fallback — use GitHub App instead)
-# gh_token = "replace_me"
-
-# Long-lived Claude OAuth token
-# Generate with: claude setup-token
-claude_oauth_token = "replace_me"
 
 # Enable Codex/Gemini CLI providers for /ask
 enable_codex_execution  = true
 enable_gemini_execution = true
-gemini_api_key          = "replace_me"
 
 # Enable MemPalace persistent cross-request memory and repo federation
 enable_mempalace        = true
 enable_mempalace_remote = true
 # Optional MemPalace remote overrides; leave blank to use app defaults.
-# mempalace_remote_token = "replace_me_or_omit_to_generate"
 # mempalace_remote_mine_on_sync = "true"
+
+# ── Secrets ──────────────────────────────────────────────────────────────
+# `terraform apply` creates empty Secret Manager containers (infra/secrets.tf).
+# Add the values yourself — they never pass through Terraform:
+#
+#   gcloud secrets versions add actuarius-discord-token             --data-file=-   # required
+#   gcloud secrets versions add actuarius-claude-oauth-token        --data-file=-   # required (claude setup-token)
+#   gcloud secrets versions add actuarius-github-app-private-key-b64 --data-file=-  # base64 of the App .pem
+#   gcloud secrets versions add actuarius-gh-token                  --data-file=-   # optional PAT fallback
+#   gcloud secrets versions add actuarius-gemini-api-key            --data-file=-   # if Gemini enabled
+#   gcloud secrets versions add actuarius-mempalace-remote-token    --data-file=-   # optional; omit to auto-generate
+#
+# Each command reads the value from stdin: paste it, then press Ctrl+D
+# (Ctrl+Z then Enter on Windows). Redeploy picks up new versions on next run.

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -45,10 +45,10 @@ variable "container_pids_limit" {
   default     = 256
 }
 
-variable "discord_token" {
-  type      = string
-  sensitive = true
-}
+# Secret values (Discord token, GitHub App private key, Claude OAuth token,
+# API keys, MemPalace federation token) are NOT Terraform variables. They live
+# in Secret Manager (infra/secrets.tf creates the containers) and are added
+# out-of-band: gcloud secrets versions add <name> --data-file=-
 
 variable "discord_client_id" {
   type      = string
@@ -62,12 +62,6 @@ variable "discord_guild_id" {
   description = "Optional: guild-scoped command registration for dev. Leave empty for global commands."
 }
 
-variable "gh_token" {
-  type        = string
-  sensitive   = true
-  default     = ""
-  description = "Optional fallback: GitHub personal access token. Prefer GitHub App auth instead."
-}
 variable "github_app_id" {
   type        = string
   sensitive   = true
@@ -80,19 +74,6 @@ variable "github_app_installation_id" {
   default     = ""
   description = "GitHub App installation ID."
 }
-variable "github_app_private_key_b64" {
-  type        = string
-  sensitive   = true
-  default     = ""
-  description = "Base64-encoded GitHub App private key (.pem)."
-}
-
-variable "claude_oauth_token" {
-  type        = string
-  sensitive   = true
-  description = "Long-lived Claude OAuth token — generate with: claude setup-token"
-}
-
 variable "enable_codex_execution" {
   type        = bool
   default     = false
@@ -141,13 +122,6 @@ variable "mempalace_remote_name" {
   description = "Optional override for MEMPALACE_REMOTE_NAME. Leave empty for the app default."
 }
 
-variable "mempalace_remote_token" {
-  type        = string
-  sensitive   = true
-  default     = ""
-  description = "Optional bearer token for local-to-remote MemPalace federation. Leave empty to generate and persist one."
-}
-
 variable "mempalace_remote_timeout_ms" {
   type        = string
   default     = ""
@@ -170,11 +144,4 @@ variable "mempalace_remote_mine_batch_size" {
   type        = string
   default     = ""
   description = "Optional override for MEMPALACE_REMOTE_MINE_BATCH_SIZE. Leave empty for the app default."
-}
-
-variable "gemini_api_key" {
-  type        = string
-  sensitive   = true
-  default     = ""
-  description = "Gemini API key required when Gemini execution is enabled"
 }

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -4,9 +4,23 @@
 #   ./redeploy.sh <sha>      # roll back to a specific git SHA
 set -euo pipefail
 
-META="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+MDS="http://metadata.google.internal/computeMetadata/v1"
+META="$MDS/instance/attributes"
 HDR="Metadata-Flavor: Google"
 get_meta() { curl -sf -H "$HDR" "$META/$1"; }
+
+# Secrets live in Secret Manager, not metadata (see infra/secrets.tf). They are
+# fetched with the VM service account's access token; only curl/sed/base64 are
+# available on Container-Optimized OS, so the JSON is parsed with sed.
+PROJECT_ID=$(curl -sf -H "$HDR" "$MDS/project/project-id")
+ACCESS_TOKEN=$(curl -sf -H "$HDR" "$MDS/instance/service-accounts/default/token" \
+  | sed -n 's/.*"access_token" *: *"\([^"]*\)".*/\1/p')
+get_secret() {
+  local response
+  response=$(curl -sf -H "Authorization: Bearer $ACCESS_TOKEN" \
+    "https://secretmanager.googleapis.com/v1/projects/$PROJECT_ID/secrets/$1/versions/latest:access") || return 1
+  printf '%s' "$response" | sed -n 's/.*"data" *: *"\([^"]*\)".*/\1/p' | base64 -d
+}
 
 IMAGE_TAG="${1:-latest}"
 BASE_IMAGE=$(get_meta "env-docker-image")
@@ -16,15 +30,15 @@ DATA_ROOT="/mnt/disks/data"
 
 echo "Deploying $IMAGE ..."
 
-DISCORD_TOKEN=$(get_meta env-discord-token)
+DISCORD_TOKEN=$(get_secret actuarius-discord-token || true)
 DISCORD_CLIENT_ID=$(get_meta env-discord-client-id)
 GUILD_ID=$(get_meta "env-discord-guild-id" || true)
-GH_TOKEN=$(get_meta "env-gh-token" || true)
+GH_TOKEN=$(get_secret actuarius-gh-token || true)
 GITHUB_APP_ID=$(get_meta "env-github-app-id" || true)
 GITHUB_APP_INSTALLATION_ID=$(get_meta "env-github-app-installation-id" || true)
-GITHUB_APP_PRIVATE_KEY=$(get_meta "env-github-app-private-key" || true)
-GITHUB_APP_PRIVATE_KEY_B64=$(get_meta "env-github-app-private-key-b64" || true)
-CLAUDE_CODE_OAUTH_TOKEN=$(get_meta env-claude-oauth-token)
+GITHUB_APP_PRIVATE_KEY=$(get_secret actuarius-github-app-private-key || true)
+GITHUB_APP_PRIVATE_KEY_B64=$(get_secret actuarius-github-app-private-key-b64 || true)
+CLAUDE_CODE_OAUTH_TOKEN=$(get_secret actuarius-claude-oauth-token || true)
 ASK_CONCURRENCY=$(get_meta env-ask-concurrency)
 CONTAINER_MEMORY=$(get_meta env-container-memory || true)
 CONTAINER_CPUS=$(get_meta env-container-cpus || true)
@@ -51,18 +65,18 @@ if $HAS_GITHUB_APP_ID && $HAS_GITHUB_APP_INSTALLATION_ID && { $HAS_GITHUB_APP_PR
   HAS_COMPLETE_GITHUB_APP_CONFIG=true
 fi
 
-if [ -z "$DISCORD_TOKEN" ];          then echo "FATAL: env-discord-token is not set"      >&2; exit 1; fi
+if [ -z "$DISCORD_TOKEN" ];          then echo "FATAL: secret actuarius-discord-token is not set"      >&2; exit 1; fi
 if [ -z "$DISCORD_CLIENT_ID" ];      then echo "FATAL: env-discord-client-id is not set"  >&2; exit 1; fi
 if $HAS_GITHUB_APP_PRIVATE_KEY && $HAS_GITHUB_APP_PRIVATE_KEY_B64; then
-  echo "FATAL: set only one of env-github-app-private-key or env-github-app-private-key-b64" >&2; exit 1
+  echo "FATAL: set only one of secret actuarius-github-app-private-key or actuarius-github-app-private-key-b64" >&2; exit 1
 fi
 if $HAS_ANY_GITHUB_APP_CONFIG && ! $HAS_COMPLETE_GITHUB_APP_CONFIG; then
-  echo "FATAL: GitHub App credentials must include env-github-app-id, env-github-app-installation-id, and exactly one of env-github-app-private-key or env-github-app-private-key-b64" >&2; exit 1
+  echo "FATAL: GitHub App credentials must include env-github-app-id, env-github-app-installation-id, and exactly one of the secrets actuarius-github-app-private-key or actuarius-github-app-private-key-b64" >&2; exit 1
 fi
 if [ -z "$GH_TOKEN" ] && ! $HAS_COMPLETE_GITHUB_APP_CONFIG; then
-  echo "FATAL: either env-gh-token or all GitHub App credentials (env-github-app-id, env-github-app-installation-id, and exactly one of env-github-app-private-key or env-github-app-private-key-b64) must be set" >&2; exit 1
+  echo "FATAL: either the actuarius-gh-token secret or all GitHub App credentials (env-github-app-id, env-github-app-installation-id, and exactly one of the secrets actuarius-github-app-private-key or actuarius-github-app-private-key-b64) must be set" >&2; exit 1
 fi
-if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ];then echo "FATAL: env-claude-oauth-token is not set" >&2; exit 1; fi
+if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ];then echo "FATAL: secret actuarius-claude-oauth-token is not set" >&2; exit 1; fi
 if [ -z "$ASK_CONCURRENCY" ];        then echo "FATAL: env-ask-concurrency is not set"     >&2; exit 1; fi
 
 ENABLE_CODEX=$(get_meta "env-enable-codex-execution" || true)
@@ -73,12 +87,12 @@ ENABLE_MEMPALACE_REMOTE=$(get_meta "env-enable-mempalace-remote" || true)
 MEMPALACE_REMOTE_URL=$(get_meta "env-mempalace-remote-url" || true)
 MEMPALACE_REMOTE_BIND=$(get_meta "env-mempalace-remote-bind" || true)
 MEMPALACE_REMOTE_NAME=$(get_meta "env-mempalace-remote-name" || true)
-MEMPALACE_REMOTE_TOKEN=$(get_meta "env-mempalace-remote-token" || true)
+MEMPALACE_REMOTE_TOKEN=$(get_secret actuarius-mempalace-remote-token || true)
 MEMPALACE_REMOTE_TIMEOUT_MS=$(get_meta "env-mempalace-remote-timeout-ms" || true)
 MEMPALACE_REMOTE_MINE_ON_SYNC=$(get_meta "env-mempalace-remote-mine-on-sync" || true)
 MEMPALACE_REMOTE_MINE_TIMEOUT_MS=$(get_meta "env-mempalace-remote-mine-timeout-ms" || true)
 MEMPALACE_REMOTE_MINE_BATCH_SIZE=$(get_meta "env-mempalace-remote-mine-batch-size" || true)
-GEMINI_API_KEY=$(get_meta "env-gemini-api-key" || true)
+GEMINI_API_KEY=$(get_secret actuarius-gemini-api-key || true)
 
 EXTRA_ARGS=()
 if [ -n "$GUILD_ID" ]; then

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -7,17 +7,24 @@ set -euo pipefail
 MDS="http://metadata.google.internal/computeMetadata/v1"
 META="$MDS/instance/attributes"
 HDR="Metadata-Flavor: Google"
-get_meta() { curl -sf -H "$HDR" "$META/$1"; }
+get_meta() { curl -sf -m 5 -H "$HDR" "$META/$1"; }
 
 # Secrets live in Secret Manager, not metadata (see infra/secrets.tf). They are
 # fetched with the VM service account's access token; only curl/sed/base64 are
-# available on Container-Optimized OS, so the JSON is parsed with sed.
-PROJECT_ID=$(curl -sf -H "$HDR" "$MDS/project/project-id")
-ACCESS_TOKEN=$(curl -sf -H "$HDR" "$MDS/instance/service-accounts/default/token" \
+# available on Container-Optimized OS, so the JSON is parsed with sed. Timeouts
+# keep a hung metadata server or API from blocking the deploy indefinitely.
+PROJECT_ID=$(curl -sf -m 5 -H "$HDR" "$MDS/project/project-id")
+if [ -z "$PROJECT_ID" ]; then
+  echo "FATAL: failed to fetch GCP project ID from the metadata server" >&2; exit 1
+fi
+ACCESS_TOKEN=$(curl -sf -m 5 -H "$HDR" "$MDS/instance/service-accounts/default/token" \
   | sed -n 's/.*"access_token" *: *"\([^"]*\)".*/\1/p')
+if [ -z "$ACCESS_TOKEN" ]; then
+  echo "FATAL: failed to fetch an access token from the metadata server" >&2; exit 1
+fi
 get_secret() {
   local response
-  response=$(curl -sf -H "Authorization: Bearer $ACCESS_TOKEN" \
+  response=$(curl -sf -m 10 -H "Authorization: Bearer $ACCESS_TOKEN" \
     "https://secretmanager.googleapis.com/v1/projects/$PROJECT_ID/secrets/$1/versions/latest:access") || return 1
   printf '%s' "$response" | sed -n 's/.*"data" *: *"\([^"]*\)".*/\1/p' | base64 -d
 }

--- a/tests/redeployScript.test.ts
+++ b/tests/redeployScript.test.ts
@@ -5,6 +5,7 @@ import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
 
 type Metadata = Record<string, string | undefined>;
+type Secrets = Record<string, string | undefined>;
 
 type RunResult = {
   status: number | null;
@@ -18,10 +19,13 @@ const scriptPath = join(repoRoot, "scripts", "redeploy.sh");
 
 const baseMetadata: Metadata = {
   "env-docker-image": "ghcr.io/digitumdei/actuarius:latest",
-  "env-discord-token": "discord-token",
   "env-discord-client-id": "discord-client-id",
-  "env-claude-oauth-token": "claude-oauth-token",
   "env-ask-concurrency": "3",
+};
+
+const baseSecrets: Secrets = {
+  "actuarius-discord-token": "discord-token",
+  "actuarius-claude-oauth-token": "claude-oauth-token",
 };
 
 const tempDirs: string[] = [];
@@ -42,24 +46,50 @@ function toBashPath(path: string): string {
   return normalized.replace(/^([A-Za-z]):/u, (_match, drive: string) => `/${drive.toLowerCase()}`);
 }
 
-function createCurlMock(metadata: Metadata): string {
-  const lines = [
-    "#!/usr/bin/env bash",
-    "url=${!#}",
-    "key=${url##*/}",
-    "case \"$key\" in",
-  ];
+function createCurlMock(metadata: Metadata, secrets: Secrets): string {
+  // Secret Manager returns the payload base64-encoded; precompute the encoded
+  // values here so the bash mock stays a static lookup table.
+  const secretCases: string[] = [];
+  for (const [name, value] of Object.entries(secrets)) {
+    if (value === undefined) {
+      continue;
+    }
+    const data = Buffer.from(value, "utf8").toString("base64");
+    secretCases.push(
+      `      ${name}) printf %s ${shellSingleQuote(`{"name":"projects/test-project/secrets/${name}/versions/1","payload":{"data":"${data}"}}`)} ;;`
+    );
+  }
 
+  const metadataCases: string[] = [];
   for (const [key, value] of Object.entries(metadata)) {
     if (value === undefined) {
       continue;
     }
-    lines.push(`  ${key}) printf %s ${shellSingleQuote(value)} ;;`);
+    metadataCases.push(`      ${key}) printf %s ${shellSingleQuote(value)} ;;`);
   }
 
-  lines.push("  *) exit 22 ;;");
-  lines.push("esac");
-  lines.push("");
+  const lines = [
+    "#!/usr/bin/env bash",
+    "url=${!#}",
+    "case \"$url\" in",
+    "  */project/project-id) printf %s 'test-project' ;;",
+    "  */service-accounts/default/token) printf %s '{\"access_token\":\"test-access-token\",\"expires_in\":3599,\"token_type\":\"Bearer\"}' ;;",
+    "  *secretmanager.googleapis.com*)",
+    "    name=\"${url##*/secrets/}\"",
+    "    name=\"${name%%/*}\"",
+    "    case \"$name\" in",
+    ...secretCases,
+    "      *) exit 22 ;;",
+    "    esac ;;",
+    "  *)",
+    "    key=${url##*/}",
+    "    case \"$key\" in",
+    ...metadataCases,
+    "      *) exit 22 ;;",
+    "    esac ;;",
+    "esac",
+    "",
+  ];
   return `${lines.join("\n")}\n`;
 }
 
@@ -91,7 +121,7 @@ exit 0
 `;
 }
 
-function runRedeploy(metadata: Metadata): RunResult {
+function runRedeploy(metadata: Metadata, secrets: Secrets = baseSecrets): RunResult {
   const tempDir = mkdtempSync(join(tmpdir(), "redeploy-test-"));
   tempDirs.push(tempDir);
 
@@ -102,7 +132,7 @@ function runRedeploy(metadata: Metadata): RunResult {
   const chownLogPath = join(tempDir, "chown.log");
   const bashEnvPath = join(tempDir, "bash-env.sh");
   writeFileSync(bashEnvPath, [
-    asBashFunction("curl", createCurlMock(metadata)),
+    asBashFunction("curl", createCurlMock(metadata, secrets)),
     asBashFunction("docker", createDockerMock(toBashPath(dockerLogPath))),
     asBashFunction("mkdir", createNoopMock(toBashPath(mkdirLogPath), "mkdir")),
     asBashFunction("chown", createNoopMock(toBashPath(chownLogPath), "chown"))
@@ -130,9 +160,9 @@ function runRedeploy(metadata: Metadata): RunResult {
 
 describe("scripts/redeploy.sh auth validation", () => {
   it("applies safe default container resource limits", () => {
-    const result = runRedeploy({
-      ...baseMetadata,
-      "env-gh-token": "gh-token",
+    const result = runRedeploy(baseMetadata, {
+      ...baseSecrets,
+      "actuarius-gh-token": "gh-token",
     });
 
     expect(result.status, result.stderr).toBe(0);
@@ -145,10 +175,12 @@ describe("scripts/redeploy.sh auth validation", () => {
   it("forwards configured container resource limits", () => {
     const result = runRedeploy({
       ...baseMetadata,
-      "env-gh-token": "gh-token",
       "env-container-memory": "600m",
       "env-container-cpus": "0.5",
       "env-container-pids-limit": "128",
+    }, {
+      ...baseSecrets,
+      "actuarius-gh-token": "gh-token",
     });
 
     expect(result.status).toBe(0);
@@ -159,9 +191,9 @@ describe("scripts/redeploy.sh auth validation", () => {
   });
 
   it("accepts GH_TOKEN-only auth and forwards only GH_TOKEN", () => {
-    const result = runRedeploy({
-      ...baseMetadata,
-      "env-gh-token": "gh-token",
+    const result = runRedeploy(baseMetadata, {
+      ...baseSecrets,
+      "actuarius-gh-token": "gh-token",
     });
 
     expect(result.status).toBe(0);
@@ -178,7 +210,9 @@ describe("scripts/redeploy.sh auth validation", () => {
       ...baseMetadata,
       "env-github-app-id": "123",
       "env-github-app-installation-id": "456",
-      "env-github-app-private-key": "-----BEGIN KEY-----\\nabc\\n-----END KEY-----",
+    }, {
+      ...baseSecrets,
+      "actuarius-github-app-private-key": "-----BEGIN KEY-----\\nabc\\n-----END KEY-----",
     });
 
     expect(result.status).toBe(0);
@@ -195,7 +229,9 @@ describe("scripts/redeploy.sh auth validation", () => {
       ...baseMetadata,
       "env-github-app-id": "123",
       "env-github-app-installation-id": "456",
-      "env-github-app-private-key-b64": "cGVtCg==",
+    }, {
+      ...baseSecrets,
+      "actuarius-github-app-private-key-b64": "cGVtCg==",
     });
 
     expect(result.status).toBe(0);
@@ -210,7 +246,7 @@ describe("scripts/redeploy.sh auth validation", () => {
     const result = runRedeploy(baseMetadata);
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("either env-gh-token or all GitHub App credentials");
+    expect(result.stderr).toContain("either the actuarius-gh-token secret or all GitHub App credentials");
     expect(result.dockerLog).toBe("");
   });
 
@@ -242,12 +278,40 @@ describe("scripts/redeploy.sh auth validation", () => {
       ...baseMetadata,
       "env-github-app-id": "123",
       "env-github-app-installation-id": "456",
-      "env-github-app-private-key": "raw-key",
-      "env-github-app-private-key-b64": "cmF3LWtleQ==",
+    }, {
+      ...baseSecrets,
+      "actuarius-github-app-private-key": "raw-key",
+      "actuarius-github-app-private-key-b64": "cmF3LWtleQ==",
     });
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("set only one of env-github-app-private-key or env-github-app-private-key-b64");
+    expect(result.stderr).toContain("set only one of secret actuarius-github-app-private-key or actuarius-github-app-private-key-b64");
     expect(result.dockerLog).toBe("");
+  });
+
+  it("fails fast when the discord token secret is missing", () => {
+    const result = runRedeploy(baseMetadata, {
+      "actuarius-claude-oauth-token": "claude-oauth-token",
+      "actuarius-gh-token": "gh-token",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("secret actuarius-discord-token is not set");
+    expect(result.dockerLog).toBe("");
+  });
+
+  it("forwards secret values fetched from Secret Manager to the container", () => {
+    const result = runRedeploy(baseMetadata, {
+      ...baseSecrets,
+      "actuarius-gh-token": "gh-token",
+      "actuarius-gemini-api-key": "gemini-key",
+      "actuarius-mempalace-remote-token": "fed-token",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.dockerLog).toContain("DISCORD_TOKEN=discord-token");
+    expect(result.dockerLog).toContain("CLAUDE_CODE_OAUTH_TOKEN=claude-oauth-token");
+    expect(result.dockerLog).toContain("GEMINI_API_KEY=gemini-key");
+    expect(result.dockerLog).toContain("MEMPALACE_REMOTE_TOKEN=fed-token");
   });
 });


### PR DESCRIPTION
## Summary

- Terraform now creates empty Secret Manager containers (`infra/secrets.tf`) and grants the VM service account `roles/secretmanager.secretAccessor`; it never sees secret values
- Secret values are added out-of-band with `gcloud secrets versions add <name> --data-file=-` and fetched by `redeploy.sh` at deploy time via the metadata-server access token (curl/sed/base64 only — works on Container-Optimized OS)
- VM instance metadata carries non-secret config only; `terraform.tfvars` is secret-free by construction
- Docs updated (deploy.md secrets section, split env-var tables, README, lessons-learned incident entry); redeploy test harness extended to mock the token endpoint and Secret Manager API

## Motivation

The 2026-07-07 incident: a saved `terraform plan -out` file swept into a public commit exposed every secret embedded in VM metadata (plan files contain full prior state in cleartext). This change removes secrets from all Terraform artifacts — tfvars, state, plans, metadata — so that entire leak class is structurally impossible.

## Migration (one-time, part of post-incident recovery)

1. `terraform apply` — creates containers, strips secret metadata keys
2. `gcloud secrets versions add` each rotated credential (commands in `terraform.tfvars.example`)
3. Refresh `/var/redeploy.sh` from metadata on the VM and run it

## Validation

- `npm run check`
- `npm test` — 630 passed, 10 skipped (2 new: missing-secret fail-fast, secret forwarding)
- `terraform fmt` / `terraform validate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)