### PR TITLE
fix: write literal federation token into agent mempalace config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ infra/*.tfplan
 
 # MemPalace
 mempalace.yaml
+
+# Terraform saved plans (embed sensitive variable values)
+*.tfplan
+tfplan*
+infra/tfplan*

--- a/src/services/memPalaceRemoteService.ts
+++ b/src/services/memPalaceRemoteService.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
-import { access, appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, appendFile, chmod, mkdir, readFile, writeFile } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { createInterface } from "node:readline";
 import { homedir } from "node:os";
@@ -423,7 +423,7 @@ export class MemPalaceRemoteService {
   }
 
   private async writeGlobalConfigOnce(): Promise<void> {
-    await this.ensureToken();
+    const remoteToken = await this.ensureToken();
     const configDir = join(this.homeDir, ".mempalace");
     const configPath = join(configDir, "config.json");
     await mkdir(configDir, { recursive: true });
@@ -439,10 +439,16 @@ export class MemPalaceRemoteService {
     const federation = isRecord(current.federation) ? { ...current.federation } : {};
     const existingRemotes = Array.isArray(federation.remotes) ? federation.remotes.filter(isRecord) : [];
     const remotes = existingRemotes.filter((remote) => remote.name !== this.config.mempalaceRemoteName);
+    // The token must be a literal here, not a token_env reference: the
+    // mempalace MCP server is spawned by each provider CLI, and several CLIs
+    // launch MCP subprocesses with only their configured env block — the
+    // bot's runtime-set MEMPALACE_REMOTE_TOKEN never crosses that boundary,
+    // so agents got HTTP 401 from the loopback remote. This file is
+    // bot-managed, rewritten on boot, and chmod 0600 below.
     remotes.push({
       name: this.config.mempalaceRemoteName,
       url: this.config.mempalaceRemoteUrl,
-      token_env: "MEMPALACE_REMOTE_TOKEN",
+      token: remoteToken,
       timeout_ms: this.config.mempalaceRemoteTimeoutMs
     });
 
@@ -484,7 +490,10 @@ export class MemPalaceRemoteService {
         kg
       }
     };
-    await writeFile(configPath, JSON.stringify(nextConfig, null, 2) + "\n", "utf8");
+    await writeFile(configPath, JSON.stringify(nextConfig, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+    // mode only applies on create; tighten pre-existing files too since the
+    // config now carries the federation token.
+    await chmod(configPath, 0o600);
   }
 
   private buildProcessEnv(): NodeJS.ProcessEnv {

--- a/tests/memPalaceRemoteService.test.ts
+++ b/tests/memPalaceRemoteService.test.ts
@@ -137,17 +137,21 @@ describe("MemPalaceRemoteService", () => {
       token_file: config.mempalaceRemoteTokenFile
     });
     expect(globalConfig.server.checkouts[wing]).toBe(checkoutPath);
+    // The remote entry carries the literal token: provider CLIs spawn the
+    // mempalace MCP server with only its configured env block, so a token_env
+    // reference to the bot's runtime environment never resolves in agents
+    // (observed as HTTP 401 from the loopback remote in /ask requests).
     expect(globalConfig.federation.remotes).toContainEqual(
       expect.objectContaining({
         name: "actuarius",
         url: config.mempalaceRemoteUrl,
-        token_env: "MEMPALACE_REMOTE_TOKEN",
+        token: "test-token",
         timeout_ms: 5000
       })
     );
     expect(globalConfig.federation.wings[wing]).toEqual({ mode: "combined", remote: "actuarius", write: "remote" });
     expect(globalConfig.federation.kg).toEqual({ mode: "combined", remote: "actuarius", write: "remote" });
-    expect(globalConfig.federation.remotes[0]).not.toHaveProperty("token");
+    expect(globalConfig.federation.remotes[0]).not.toHaveProperty("token_env");
 
     const tokenEntries = JSON.parse(readFileSync(config.mempalaceRemoteTokenFile, "utf8"));
     expect(tokenEntries[0]).toMatchObject({ name: "actuarius-local", token: "test-token", enabled: true });


### PR DESCRIPTION
## Summary

Agents running inside `/ask` requests got HTTP 401 from the loopback MemPalace remote. The bot-managed `~/.mempalace/config.json` referenced the token via `token_env: MEMPALACE_REMOTE_TOKEN`, but provider CLIs spawn the mempalace MCP server with only its configured env block, so the bot''s runtime-set variable never reaches the process that resolves it. The operator''s working tunnel client already uses a literal `token` field, which the mempalace client supports.

- Write the literal token into the remote entry instead of a `token_env` reference
- `chmod 0600` the config since it now carries a credential (applies to pre-existing files too)
- Existing deployments self-heal: the writer replaces the named remote entry wholesale on next boot

## Validation

- `npm run check`
- `npm test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)