### PR TITLE
feat: ship container logs to Cloud Logging

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -93,11 +93,11 @@ from anywhere with gcloud:
 
 ```bash
 # Last 30 minutes of bot logs
-gcloud logging read 'logName:cos_containers AND jsonPayload.container_name="actuarius"' \
+gcloud logging read 'logName:cos_containers AND jsonPayload."cos.googleapis.com/container_name"="actuarius"' \
   --freshness=30m --limit=100 --order=desc --format='value(timestamp, jsonPayload.message)'
 
 # Live tail
-gcloud alpha logging tail 'jsonPayload.container_name="actuarius"'
+gcloud alpha logging tail 'jsonPayload."cos.googleapis.com/container_name"="actuarius"'
 ```
 
 Or use the Logs Explorer in the GCP Console. The bot logs structured JSON

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -84,6 +84,27 @@ Local Docker Compose uses the same defaults. Override them with
 `ACTUARIUS_CONTAINER_PIDS_LIMIT` when a development machine has different
 capacity.
 
+## Logs (no SSH needed)
+
+The VM metadata sets `google-logging-enabled = "true"`, which turns on the
+Container-Optimized OS logging agent: all container stdout/stderr streams to
+Cloud Logging (the service account has `roles/logging.logWriter`). Read logs
+from anywhere with gcloud:
+
+```bash
+# Last 30 minutes of bot logs
+gcloud logging read 'logName:cos_containers AND jsonPayload.container_name="actuarius"' \
+  --freshness=30m --limit=100 --order=desc --format='value(timestamp, jsonPayload.message)'
+
+# Live tail
+gcloud alpha logging tail 'jsonPayload.container_name="actuarius"'
+```
+
+Or use the Logs Explorer in the GCP Console. The bot logs structured JSON
+(pino), so fields like `level` and `msg` are queryable. Within the free tier
+(50 GiB/month ingestion, 30-day retention) this costs nothing at this bot's
+volume. `docker logs actuarius` over SSH still works as a fallback.
+
 ## MemPalace Remote
 
 To run the local MemPalace MCP plus Actuarius' loopback remote repo store in production, set both Terraform switches:

--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -46,6 +46,10 @@ resource "google_compute_instance" "actuarius" {
   # time — never through Terraform, so they cannot leak via tfvars, state, or
   # plan files.
   metadata = {
+    # COS built-in Cloud Logging agent: streams all container stdout/stderr to
+    # Cloud Logging so logs are readable without SSH (needs logging.logWriter).
+    google-logging-enabled = "true"
+
     env-discord-client-id                = var.discord_client_id
     env-discord-guild-id                 = var.discord_guild_id
     env-github-app-id                    = var.github_app_id

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -3,9 +3,15 @@ resource "google_service_account" "actuarius_bot" {
   display_name = "Actuarius Bot"
 }
 
+resource "google_project_service" "logging" {
+  service            = "logging.googleapis.com"
+  disable_on_destroy = false
+}
+
 # Lets the COS Cloud Logging agent ship container logs to Cloud Logging.
 resource "google_project_iam_member" "bot_log_writer" {
-  project = var.gcp_project_id
-  role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${google_service_account.actuarius_bot.email}"
+  depends_on = [google_project_service.logging]
+  project    = var.gcp_project_id
+  role       = "roles/logging.logWriter"
+  member     = "serviceAccount:${google_service_account.actuarius_bot.email}"
 }

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -2,3 +2,10 @@ resource "google_service_account" "actuarius_bot" {
   account_id   = "actuarius-bot"
   display_name = "Actuarius Bot"
 }
+
+# Lets the COS Cloud Logging agent ship container logs to Cloud Logging.
+resource "google_project_iam_member" "bot_log_writer" {
+  project = var.gcp_project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.actuarius_bot.email}"
+}


### PR DESCRIPTION
## Summary
- Enable the Container-Optimized OS logging agent (`google-logging-enabled = "true"` VM metadata) so all container stdout/stderr streams to Cloud Logging
- Grant the bot service account `roles/logging.logWriter`
- Document no-SSH log access (`gcloud logging read` / live tail) in docs/deploy.md

## Why
Debugging today required `docker logs` over an IAP SSH tunnel, which is slow and flaky. With this change logs are queryable from anywhere via gcloud or Logs Explorer. Volume is far inside the 50 GiB/month free tier, so cost is $0.

## Deploy notes
Requires `terraform apply` (metadata + IAM only — no VM recreation, no container restart needed; the logging agent picks up on the metadata change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)