### PR TITLE
fix: reconcile interrupted requests on startup

### DIFF
--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -618,14 +618,46 @@ export class AppDatabase {
   // deployment), so any row still marked active was interrupted by a restart.
   // Left as-is, such rows block their thread ("already queued or running")
   // and their install root ("INSTALL_ALREADY_ACTIVE") forever.
-  public failInterruptedWork(): { requests: number; installRequests: number } {
-    const requests = this.db
-      .prepare("UPDATE requests SET status = 'failed' WHERE status IN ('queued', 'running', 'install_approved', 'install_running')")
-      .run();
-    const installRequests = this.db
-      .prepare("UPDATE install_requests SET status = 'failed' WHERE status IN ('approved', 'running')")
-      .run();
-    return { requests: Number(requests.changes), installRequests: Number(installRequests.changes) };
+  public failInterruptedWork(): { requests: number; installRequests: number; reviewRuns: number } {
+    this.db.exec("BEGIN");
+    try {
+      // An install may have reached a terminal outcome on its own row before
+      // the process died, leaving only the request row behind. Derive the
+      // request status from the latest linked install request rather than
+      // stamping a completed install as failed.
+      const installSucceeded = this.db
+        .prepare(
+          `UPDATE requests SET status = 'install_succeeded'
+           WHERE status IN ('install_approved', 'install_running')
+             AND (SELECT ir.status FROM install_requests ir WHERE ir.request_id = requests.id ORDER BY ir.id DESC LIMIT 1) = 'succeeded'`
+        )
+        .run();
+      const installFailed = this.db
+        .prepare(
+          `UPDATE requests SET status = 'install_failed'
+           WHERE status IN ('install_approved', 'install_running')
+             AND (SELECT ir.status FROM install_requests ir WHERE ir.request_id = requests.id ORDER BY ir.id DESC LIMIT 1) = 'failed'`
+        )
+        .run();
+      const requests = this.db
+        .prepare("UPDATE requests SET status = 'failed' WHERE status IN ('queued', 'running', 'install_approved', 'install_running')")
+        .run();
+      const installRequests = this.db
+        .prepare("UPDATE install_requests SET status = 'failed' WHERE status IN ('approved', 'running')")
+        .run();
+      const reviewRuns = this.db
+        .prepare("UPDATE review_runs SET status = 'failed', updated_at = CURRENT_TIMESTAMP WHERE status = 'running'")
+        .run();
+      this.db.exec("COMMIT");
+      return {
+        requests: Number(installSucceeded.changes) + Number(installFailed.changes) + Number(requests.changes),
+        installRequests: Number(installRequests.changes),
+        reviewRuns: Number(reviewRuns.changes)
+      };
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
   }
 
   public updateRequestWorkspace(requestId: number, worktreePath: string | null, branchName: string | null): void {

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -614,6 +614,20 @@ export class AppDatabase {
     this.db.prepare("UPDATE requests SET status = ? WHERE id = ?").run(status, requestId);
   }
 
+  // A freshly booted process has no in-flight work (single-instance
+  // deployment), so any row still marked active was interrupted by a restart.
+  // Left as-is, such rows block their thread ("already queued or running")
+  // and their install root ("INSTALL_ALREADY_ACTIVE") forever.
+  public failInterruptedWork(): { requests: number; installRequests: number } {
+    const requests = this.db
+      .prepare("UPDATE requests SET status = 'failed' WHERE status IN ('queued', 'running', 'install_approved', 'install_running')")
+      .run();
+    const installRequests = this.db
+      .prepare("UPDATE install_requests SET status = 'failed' WHERE status IN ('approved', 'running')")
+      .run();
+    return { requests: Number(requests.changes), installRequests: Number(installRequests.changes) };
+  }
+
   public updateRequestWorkspace(requestId: number, worktreePath: string | null, branchName: string | null): void {
     this.db.prepare("UPDATE requests SET worktree_path = ?, branch_name = ? WHERE id = ?").run(worktreePath, branchName, requestId);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
   db.runMigrations();
 
   const interrupted = db.failInterruptedWork();
-  if (interrupted.requests > 0 || interrupted.installRequests > 0) {
+  if (interrupted.requests > 0 || interrupted.installRequests > 0 || interrupted.reviewRuns > 0) {
     logger.warn(interrupted, "Marked requests interrupted by the previous shutdown as failed");
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,11 @@ async function main(): Promise<void> {
   const db = new AppDatabase(appConfig.databasePath);
   db.runMigrations();
 
+  const interrupted = db.failInterruptedWork();
+  if (interrupted.requests > 0 || interrupted.installRequests > 0) {
+    logger.warn(interrupted, "Marked requests interrupted by the previous shutdown as failed");
+  }
+
   await initializeGitHubAuth(appConfig, logger);
   runCapabilityChecks(logger);
   await registerSlashCommands(appConfig, logger);

--- a/tests/databaseRequests.test.ts
+++ b/tests/databaseRequests.test.ts
@@ -531,6 +531,7 @@ describe("AppDatabase startup reconciliation of interrupted work", () => {
     const result = db.failInterruptedWork();
 
     expect(result.requests).toBe(4);
+    expect(result.reviewRuns).toBe(0);
     expect(db.getRequestByThreadId("thread-queued")?.status).toBe("failed");
     expect(db.getRequestByThreadId("thread-running")?.status).toBe("failed");
     expect(db.getRequestByThreadId("thread-install-approved")?.status).toBe("failed");
@@ -560,9 +561,69 @@ describe("AppDatabase startup reconciliation of interrupted work", () => {
     expect(db.getActiveInstallRequestByRoot("/data/installs/repo-1")).toBeUndefined();
   });
 
+  it("preserves a completed install outcome instead of failing the request", () => {
+    const request = createRequestWithStatus("thread-install-done", "install_running");
+    const install = db.createInstallRequest({
+      guildId: "guild-1",
+      repoId: 1,
+      requestId: request.id,
+      packageId: "pkg",
+      packageVersion: "1.0.0",
+      scope: "request",
+      status: "approved",
+      requestedByUserId: "user-1",
+      installRoot: "/data/installs/request-done"
+    });
+    db.updateInstallRequest({ installRequestId: install.id, status: "succeeded" });
+
+    const result = db.failInterruptedWork();
+
+    expect(result.requests).toBe(1);
+    expect(db.getRequestByThreadId("thread-install-done")?.status).toBe("install_succeeded");
+  });
+
+  it("derives install_failed when the linked install already failed", () => {
+    const request = createRequestWithStatus("thread-install-lost", "install_running");
+    const install = db.createInstallRequest({
+      guildId: "guild-1",
+      repoId: 1,
+      requestId: request.id,
+      packageId: "pkg",
+      packageVersion: "1.0.0",
+      scope: "request",
+      status: "approved",
+      requestedByUserId: "user-1",
+      installRoot: "/data/installs/request-lost"
+    });
+    db.updateInstallRequest({ installRequestId: install.id, status: "failed" });
+
+    const result = db.failInterruptedWork();
+
+    expect(result.requests).toBe(1);
+    expect(db.getRequestByThreadId("thread-install-lost")?.status).toBe("install_failed");
+  });
+
+  it("fails interrupted review runs", () => {
+    const request = createRequestWithStatus("thread-review", "succeeded");
+    db.createReviewRun({
+      requestId: request.id,
+      threadId: "thread-review",
+      branchName: "ask/1-123",
+      status: "running",
+      configJson: "{}",
+      diffBase: "origin/main",
+      diffHead: "sha"
+    });
+
+    const result = db.failInterruptedWork();
+
+    expect(result.reviewRuns).toBe(1);
+    expect(db.getLatestReviewRunForRequest(request.id)?.status).toBe("failed");
+  });
+
   it("reports zero changes when there is nothing to reconcile", () => {
     createRequestWithStatus("thread-done", "succeeded");
 
-    expect(db.failInterruptedWork()).toEqual({ requests: 0, installRequests: 0 });
+    expect(db.failInterruptedWork()).toEqual({ requests: 0, installRequests: 0, reviewRuns: 0 });
   });
 });

--- a/tests/databaseRequests.test.ts
+++ b/tests/databaseRequests.test.ts
@@ -490,3 +490,79 @@ describe("AppDatabase migration from legacy reviewer_slots", () => {
     expect(db.getReviewerSlots("guild-1")).toEqual([]);
   });
 });
+
+describe("AppDatabase startup reconciliation of interrupted work", () => {
+  let db: AppDatabase;
+
+  beforeEach(() => {
+    db = createInMemoryDb();
+    db.upsertGuild("guild-1", "Test Guild");
+    db.createRepo({
+      guildId: "guild-1",
+      owner: "octocat",
+      repo: "hello-world",
+      fullName: "octocat/hello-world",
+      visibility: "private",
+      channelId: "channel-1",
+      linkedByUserId: "user-1"
+    });
+  });
+
+  function createRequestWithStatus(threadId: string, status: "queued" | "running" | "succeeded" | "failed" | "install_approved" | "install_running") {
+    return db.createRequest({
+      guildId: "guild-1",
+      repoId: 1,
+      channelId: "channel-1",
+      threadId,
+      userId: "user-1",
+      prompt: "prompt",
+      status
+    });
+  }
+
+  it("fails requests left in an active status and leaves terminal ones alone", () => {
+    const queued = createRequestWithStatus("thread-queued", "queued");
+    const running = createRequestWithStatus("thread-running", "running");
+    const installApproved = createRequestWithStatus("thread-install-approved", "install_approved");
+    const installRunning = createRequestWithStatus("thread-install-running", "install_running");
+    const succeeded = createRequestWithStatus("thread-succeeded", "succeeded");
+    const failed = createRequestWithStatus("thread-failed", "failed");
+
+    const result = db.failInterruptedWork();
+
+    expect(result.requests).toBe(4);
+    expect(db.getRequestByThreadId("thread-queued")?.status).toBe("failed");
+    expect(db.getRequestByThreadId("thread-running")?.status).toBe("failed");
+    expect(db.getRequestByThreadId("thread-install-approved")?.status).toBe("failed");
+    expect(db.getRequestByThreadId("thread-install-running")?.status).toBe("failed");
+    expect(db.getRequestByThreadId("thread-succeeded")?.status).toBe("succeeded");
+    expect(db.getRequestByThreadId("thread-failed")?.status).toBe("failed");
+    expect([queued.id, running.id, installApproved.id, installRunning.id, succeeded.id, failed.id]).toHaveLength(6);
+  });
+
+  it("fails active install requests so the install root is released", () => {
+    db.createInstallRequest({
+      guildId: "guild-1",
+      repoId: 1,
+      packageId: "pkg",
+      packageVersion: "1.0.0",
+      scope: "repo",
+      status: "approved",
+      requestedByUserId: "user-1",
+      installRoot: "/data/installs/repo-1"
+    });
+
+    expect(db.getActiveInstallRequestByRoot("/data/installs/repo-1")).toBeDefined();
+
+    const result = db.failInterruptedWork();
+
+    expect(result.installRequests).toBe(1);
+    expect(db.getActiveInstallRequestByRoot("/data/installs/repo-1")).toBeUndefined();
+  });
+
+  it("reports zero changes when there is nothing to reconcile", () => {
+    createRequestWithStatus("thread-done", "succeeded");
+
+    expect(db.failInterruptedWork()).toEqual({ requests: 0, installRequests: 0 });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `AppDatabase.failInterruptedWork()`: marks `requests` rows stuck in `queued`/`running`/`install_approved`/`install_running` and `install_requests` rows stuck in `approved`/`running` as `failed`
- Call it at boot in `src/index.ts` right after migrations, with a warn log when anything was reconciled
- Tests for all active/terminal status combinations and install-root release

## Why
A container restart mid-request (reboot, OOM, crash-loop — e.g. yesterday''s federation-server restart loop) orphans the DB row in an active status. The per-thread guard then permanently rejects follow-ups with "Another request in this thread is already queued or running", and stale install requests permanently block their install root. Observed in production: a thread bricked by a request interrupted by last night''s reboot.

Since deployment is single-instance, a freshly booted process provably has no in-flight work, so failing all active rows at startup is safe — and deploying this fix automatically unbricks the currently stuck thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)