### PR TITLE
fix: let the container use the VM swapfile again

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - actuarius_data:/data
     mem_limit: ${ACTUARIUS_CONTAINER_MEMORY:-700m}
-    memswap_limit: ${ACTUARIUS_CONTAINER_MEMORY:-700m}
+    memswap_limit: ${ACTUARIUS_CONTAINER_MEMORY_SWAP:-2g}
     cpus: ${ACTUARIUS_CONTAINER_CPUS:-0.8}
     pids_limit: ${ACTUARIUS_CONTAINER_PIDS_LIMIT:-256}
     restart: unless-stopped

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -73,16 +73,21 @@ sudo reboot
 3. Stops and removes the old container
 4. Starts a new container with the correct env vars mapped from metadata
 
-Production deploys constrain the container to 700 MB RAM with no extra swap,
+Production deploys constrain the container to 700 MB RAM, 2 GB memory+swap,
 0.8 CPU, and 256 processes by default. These cgroup limits keep provider builds
-or fork storms from starving the VM host. Override them with Terraform variables
-`container_memory`, `container_cpus`, and `container_pids_limit`; keep the memory
-limit below total VM RAM so Docker, SSH, and system services retain headroom.
+or fork storms from starving the VM host. The swap allowance matters: the VM
+provisions a 1536 MB swapfile (`infra/startup.sh`) so heavy provider CLI
+subprocesses spill to swap instead of being SIGKILLed by the OOM killer.
+Override the limits with Terraform variables `container_memory`,
+`container_memory_swap`, `container_cpus`, and `container_pids_limit`; keep the
+memory limit below total VM RAM so Docker, SSH, and system services retain
+headroom, and set `container_memory_swap` equal to `container_memory` to
+disable swap entirely.
 
 Local Docker Compose uses the same defaults. Override them with
-`ACTUARIUS_CONTAINER_MEMORY`, `ACTUARIUS_CONTAINER_CPUS`, and
-`ACTUARIUS_CONTAINER_PIDS_LIMIT` when a development machine has different
-capacity.
+`ACTUARIUS_CONTAINER_MEMORY`, `ACTUARIUS_CONTAINER_MEMORY_SWAP`,
+`ACTUARIUS_CONTAINER_CPUS`, and `ACTUARIUS_CONTAINER_PIDS_LIMIT` when a
+development machine has different capacity.
 
 ## Logs (no SSH needed)
 

--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -57,6 +57,7 @@ resource "google_compute_instance" "actuarius" {
     env-docker-image                     = var.docker_image
     env-ask-concurrency                  = var.ask_concurrency
     env-container-memory                 = var.container_memory
+    env-container-memory-swap            = var.container_memory_swap
     env-container-cpus                   = var.container_cpus
     env-container-pids-limit             = var.container_pids_limit
     env-enable-codex-execution           = var.enable_codex_execution

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -10,6 +10,7 @@ gcp_zone       = "us-east1-b"
 docker_image      = "ghcr.io/digitumdei/actuarius:latest"
 ask_concurrency   = 1
 container_memory  = "700m"
+container_memory_swap = "2g"   # memory+swap total; equal to container_memory disables swap
 container_cpus    = "0.8"
 container_pids_limit = 256
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -29,8 +29,14 @@ variable "ask_concurrency" {
 
 variable "container_memory" {
   type        = string
-  description = "Docker memory and memory+swap limit. Keep below VM RAM to preserve host headroom."
+  description = "Docker RAM limit. Keep below VM RAM to preserve host headroom."
   default     = "700m"
+}
+
+variable "container_memory_swap" {
+  type        = string
+  description = "Docker memory+swap total (--memory-swap). Must be >= container_memory; set equal to it to disable swap. The VM provisions a 1536M swapfile for provider CLI subprocesses."
+  default     = "2g"
 }
 
 variable "container_cpus" {

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -60,6 +60,31 @@ CONTAINER_MEMORY_SWAP="${CONTAINER_MEMORY_SWAP:-2g}"
 CONTAINER_CPUS="${CONTAINER_CPUS:-0.8}"
 CONTAINER_PIDS_LIMIT="${CONTAINER_PIDS_LIMIT:-256}"
 
+# Docker requires --memory-swap >= --memory (it is the memory+swap TOTAL).
+# If a larger memory override predates the swap knob, raise the swap total to
+# match rather than letting docker run fail after the old container is gone.
+to_bytes() {
+  local v n unit
+  v=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  v="${v%b}"
+  case "$v" in
+    *k) unit=1024; n="${v%k}" ;;
+    *m) unit=$((1024 * 1024)); n="${v%m}" ;;
+    *g) unit=$((1024 * 1024 * 1024)); n="${v%g}" ;;
+    *) unit=1; n="$v" ;;
+  esac
+  case "$n" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  printf '%s' "$((n * unit))"
+}
+MEM_BYTES=$(to_bytes "$CONTAINER_MEMORY" || true)
+SWAP_BYTES=$(to_bytes "$CONTAINER_MEMORY_SWAP" || true)
+if [ -n "$MEM_BYTES" ] && [ -n "$SWAP_BYTES" ] && [ "$SWAP_BYTES" -lt "$MEM_BYTES" ]; then
+  echo "WARN: container memory-swap $CONTAINER_MEMORY_SWAP is below memory $CONTAINER_MEMORY; raising it to $CONTAINER_MEMORY (no swap)" >&2
+  CONTAINER_MEMORY_SWAP="$CONTAINER_MEMORY"
+fi
+
 HAS_GITHUB_APP_ID=false
 HAS_GITHUB_APP_INSTALLATION_ID=false
 HAS_GITHUB_APP_PRIVATE_KEY=false

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -48,10 +48,15 @@ GITHUB_APP_PRIVATE_KEY_B64=$(get_secret actuarius-github-app-private-key-b64 || 
 CLAUDE_CODE_OAUTH_TOKEN=$(get_secret actuarius-claude-oauth-token || true)
 ASK_CONCURRENCY=$(get_meta env-ask-concurrency)
 CONTAINER_MEMORY=$(get_meta env-container-memory || true)
+CONTAINER_MEMORY_SWAP=$(get_meta env-container-memory-swap || true)
 CONTAINER_CPUS=$(get_meta env-container-cpus || true)
 CONTAINER_PIDS_LIMIT=$(get_meta env-container-pids-limit || true)
 
 CONTAINER_MEMORY="${CONTAINER_MEMORY:-700m}"
+# memory+swap total. The VM provisions a 1536M swapfile (infra/startup.sh)
+# specifically so provider CLI subprocesses can spill past RAM instead of
+# being OOM-killed; 2g leaves the host ~230M of swap headroom.
+CONTAINER_MEMORY_SWAP="${CONTAINER_MEMORY_SWAP:-2g}"
 CONTAINER_CPUS="${CONTAINER_CPUS:-0.8}"
 CONTAINER_PIDS_LIMIT="${CONTAINER_PIDS_LIMIT:-256}"
 
@@ -181,7 +186,7 @@ docker run -d \
   --name actuarius \
   --restart unless-stopped \
   --memory "$CONTAINER_MEMORY" \
-  --memory-swap "$CONTAINER_MEMORY" \
+  --memory-swap "$CONTAINER_MEMORY_SWAP" \
   --cpus "$CONTAINER_CPUS" \
   --pids-limit "$CONTAINER_PIDS_LIMIT" \
   -v "$DATA_ROOT:/data" \

--- a/tests/redeployScript.test.ts
+++ b/tests/redeployScript.test.ts
@@ -167,7 +167,7 @@ describe("scripts/redeploy.sh auth validation", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.dockerLog).toContain("--memory\n700m");
-    expect(result.dockerLog).toContain("--memory-swap\n700m");
+    expect(result.dockerLog).toContain("--memory-swap\n2g");
     expect(result.dockerLog).toContain("--cpus\n0.8");
     expect(result.dockerLog).toContain("--pids-limit\n256");
   });
@@ -176,6 +176,7 @@ describe("scripts/redeploy.sh auth validation", () => {
     const result = runRedeploy({
       ...baseMetadata,
       "env-container-memory": "600m",
+      "env-container-memory-swap": "600m",
       "env-container-cpus": "0.5",
       "env-container-pids-limit": "128",
     }, {

--- a/tests/redeployScript.test.ts
+++ b/tests/redeployScript.test.ts
@@ -191,6 +191,21 @@ describe("scripts/redeploy.sh auth validation", () => {
     expect(result.dockerLog).toContain("--pids-limit\n128");
   });
 
+  it("raises memory-swap to match a larger memory override", () => {
+    const result = runRedeploy({
+      ...baseMetadata,
+      "env-container-memory": "3g",
+    }, {
+      ...baseSecrets,
+      "actuarius-gh-token": "gh-token",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("raising it to 3g");
+    expect(result.dockerLog).toContain("--memory\n3g");
+    expect(result.dockerLog).toContain("--memory-swap\n3g");
+  });
+
   it("accepts GH_TOKEN-only auth and forwards only GH_TOKEN", () => {
     const result = runRedeploy(baseMetadata, {
       ...baseSecrets,


### PR DESCRIPTION
## Summary
- New `container_memory_swap` Terraform variable → `env-container-memory-swap` metadata → `--memory-swap` in redeploy.sh (default `2g`)
- docker-compose gains matching `ACTUARIUS_CONTAINER_MEMORY_SWAP` (default `2g`)
- Docs updated (deploy.md resource-limits section, tfvars example)

## Why
The provider-reliability hardening set `--memory-swap` = `--memory` (700m/700m), which disables container swap entirely — silently defeating the 1536 MB swapfile `infra/startup.sh` deliberately provisions for provider CLI subprocesses. Result observed in production today: OpenCode requests on a large repo SIGKILLed by the cgroup OOM killer (requests 944 and 945, `container oom` events at 2026-07-08T16:41:36Z), surfaced in Discord as "Process exited with code null".

With `--memory 700m --memory-swap 2g` the container keeps its 700 MB RAM cap but can spill ~1.3 GB to swap, restoring the pre-hardening behaviour. Setting `container_memory_swap` equal to `container_memory` restores the no-swap hard cap for anyone who wants it.

## Deploy notes
Requires `terraform apply` (metadata only) and a redeploy so the container is recreated with the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)