### PR TITLE
Add progress-aware provider timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,17 @@ REPOS_ROOT_PATH=/data/repos
 LOG_LEVEL=info
 THREAD_AUTO_ARCHIVE_MINUTES=1440
 ASK_CONCURRENCY_PER_GUILD=3
-ASK_EXECUTION_TIMEOUT_MS=1200000
-ITERATIVE_VERIFICATION_TIMEOUT_MS=300000
+# Timeout overrides in milliseconds. All timeout defaults are defined together
+# in src/config.ts as TIMEOUT_DEFAULTS_MS.
+ASK_EXECUTION_TIMEOUT_MS=5400000
+# Kill a provider that stops producing both stdout and stderr. Any output resets this timer.
+PROVIDER_IDLE_TIMEOUT_MS=900000
+# Fixed cap for each primary reviewer in each consensus round.
+REVIEWER_TIMEOUT_MS=1200000
+ITERATIVE_VERIFICATION_TIMEOUT_MS=600000
+INSTALL_STEP_TIMEOUT_MS=3600000
+MEMPALACE_REMOTE_TIMEOUT_MS=5000
+MEMPALACE_REMOTE_MINE_TIMEOUT_MS=2700000
 REVIEW_CONCURRENCY=1
 # Required for Gemini execution when ENABLE_GEMINI_EXECUTION=true
 # GEMINI_API_KEY=replace_me

--- a/README.md
+++ b/README.md
@@ -51,9 +51,7 @@ Copy `.env.example` to `.env` and set:
 - `LOG_LEVEL` (default `info`)
 - `THREAD_AUTO_ARCHIVE_MINUTES` (`60`, `1440`, `4320`, or `10080`)
 - `ASK_CONCURRENCY_PER_GUILD` (default `3`)
-- `ITERATIVE_VERIFICATION_TIMEOUT_MS` (default `300000`, bounds each iterative planner verification)
 - `REVIEW_CONCURRENCY` (default `1`, serialize reviewers on memory-constrained hosts)
-- `ASK_EXECUTION_TIMEOUT_MS` (default `1200000`)
 - `ENABLE_CODEX_EXECUTION` (default `false`, enables Codex/OpenAI provider)
 - `ENABLE_GEMINI_EXECUTION` (default `false`, enables Gemini provider)
 - `ENABLE_OPENCODE_EXECUTION` (default `false`, enables OpenCode/DeepSeek provider)
@@ -65,6 +63,15 @@ Copy `.env.example` to `.env` and set:
 - `MEMPALACE_REMOTE_URL` (default `http://127.0.0.1:8765`)
 - `MEMPALACE_REMOTE_TOKEN` (optional; generated and persisted if omitted)
 - `MEMPALACE_REMOTE_MINE_ON_SYNC` (default `true`, queues repo mining after connect/sync/checkouts)
+
+All timeout defaults live together in [`TIMEOUT_DEFAULTS_MS`](src/config.ts) and can be overridden with these millisecond-valued environment variables:
+
+- `ASK_EXECUTION_TIMEOUT_MS` — absolute cap for a provider invocation (default `5400000`)
+- `PROVIDER_IDLE_TIMEOUT_MS` — no-output timeout for a provider (default `900000`)
+- `REVIEWER_TIMEOUT_MS` — fixed cap for each primary reviewer per round (default `1200000`)
+- `ITERATIVE_VERIFICATION_TIMEOUT_MS` — iterative planner-verification cap (default `600000`)
+- `INSTALL_STEP_TIMEOUT_MS` — tool-install step cap (default `3600000`)
+- `MEMPALACE_REMOTE_TIMEOUT_MS` and `MEMPALACE_REMOTE_MINE_TIMEOUT_MS` — remote request and mine-operation caps (defaults `5000` and `2700000`)
 
 Provider CLI auth state is persisted under `/data/home/appuser` inside the container. The provider CLIs themselves are also installed under `/data/home/appuser/.npm-global`, with `docker/entrypoint.sh` seeding them on first boot if missing. That keeps Claude and Codex authentication and CLI updates across container replacement, because production mounts `/data` from the persistent disk. Gemini and OpenCode execution use API keys instead of persisted OAuth state — set `GEMINI_API_KEY` / `DEEPSEEK_API_KEY` as env vars, or use `/opencode-auth` to store per-provider keys in `auth.json` with support for DeepSeek, OpenAI, Anthropic, Google, xAI, Groq, OpenRouter, and Together.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,20 @@ loadDotEnv();
 const allowedArchiveDurations = [60, 1440, 4320, 10080] as const;
 type AllowedArchiveDuration = (typeof allowedArchiveDurations)[number];
 
+/**
+ * Default durations for every configurable timeout. Environment variables use
+ * the same name with `_MS` appended and override these values at runtime.
+ */
+export const TIMEOUT_DEFAULTS_MS = {
+  askExecution: 90 * 60 * 1000,
+  providerIdle: 15 * 60 * 1000,
+  reviewer: 20 * 60 * 1000,
+  iterativeVerification: 10 * 60 * 1000,
+  installStep: 60 * 60 * 1000,
+  mempalaceRemote: 5 * 1000,
+  mempalaceRemoteMine: 45 * 60 * 1000,
+} as const;
+
 function normalizeArchiveDuration(rawValue: number): AllowedArchiveDuration {
   if (allowedArchiveDurations.includes(rawValue as AllowedArchiveDuration)) {
     return rawValue as AllowedArchiveDuration;
@@ -50,12 +64,22 @@ const envSchema = z.object({
     .refine((value) => Number.isFinite(value) && value > 0, "ASK_CONCURRENCY_PER_GUILD must be a positive number"),
   ASK_EXECUTION_TIMEOUT_MS: z
     .string()
-    .default("2700000")
+    .default(String(TIMEOUT_DEFAULTS_MS.askExecution))
     .transform((value) => Number.parseInt(value, 10))
     .refine((value) => Number.isFinite(value) && value > 0, "ASK_EXECUTION_TIMEOUT_MS must be a positive number"),
+  PROVIDER_IDLE_TIMEOUT_MS: z
+    .string()
+    .default(String(TIMEOUT_DEFAULTS_MS.providerIdle))
+    .transform((value) => Number.parseInt(value, 10))
+    .refine((value) => Number.isFinite(value) && value > 0, "PROVIDER_IDLE_TIMEOUT_MS must be a positive number"),
+  REVIEWER_TIMEOUT_MS: z
+    .string()
+    .default(String(TIMEOUT_DEFAULTS_MS.reviewer))
+    .transform((value) => Number.parseInt(value, 10))
+    .refine((value) => Number.isFinite(value) && value > 0, "REVIEWER_TIMEOUT_MS must be a positive number"),
   ITERATIVE_VERIFICATION_TIMEOUT_MS: z
     .string()
-    .default("300000")
+    .default(String(TIMEOUT_DEFAULTS_MS.iterativeVerification))
     .transform((value) => Number.parseInt(value, 10))
     .refine((value) => Number.isFinite(value) && value > 0, "ITERATIVE_VERIFICATION_TIMEOUT_MS must be a positive number"),
   REVIEW_CONCURRENCY: z
@@ -65,7 +89,7 @@ const envSchema = z.object({
     .refine((value) => Number.isFinite(value) && value > 0, "REVIEW_CONCURRENCY must be a positive number"),
   INSTALL_STEP_TIMEOUT_MS: z
     .string()
-    .default("3600000")
+    .default(String(TIMEOUT_DEFAULTS_MS.installStep))
     .transform((value) => Number.parseInt(value, 10))
     .refine((value) => Number.isFinite(value) && value > 0, "INSTALL_STEP_TIMEOUT_MS must be a positive number"),
   APT_INSTALL_HELPER_PATH: optionalNonEmpty,
@@ -116,9 +140,9 @@ const envSchema = z.object({
   MEMPALACE_REMOTE_NAME: z.string().default("actuarius"),
   MEMPALACE_REMOTE_TOKEN: optionalNonEmpty,
   MEMPALACE_REMOTE_TOKEN_FILE: z.string().default("/data/mempalace/server_tokens.json"),
-  MEMPALACE_REMOTE_TIMEOUT_MS: z.string().default("5000").transform((value) => Number.parseInt(value, 10)).refine((value) => Number.isFinite(value) && value > 0, "MEMPALACE_REMOTE_TIMEOUT_MS must be a positive number"),
+  MEMPALACE_REMOTE_TIMEOUT_MS: z.string().default(String(TIMEOUT_DEFAULTS_MS.mempalaceRemote)).transform((value) => Number.parseInt(value, 10)).refine((value) => Number.isFinite(value) && value > 0, "MEMPALACE_REMOTE_TIMEOUT_MS must be a positive number"),
   MEMPALACE_REMOTE_MINE_ON_SYNC: z.string().default("true").transform((value) => value === "true"),
-  MEMPALACE_REMOTE_MINE_TIMEOUT_MS: z.string().default("2700000").transform((value) => Number.parseInt(value, 10)).refine((value) => Number.isFinite(value) && value > 0, "MEMPALACE_REMOTE_MINE_TIMEOUT_MS must be a positive number"),
+  MEMPALACE_REMOTE_MINE_TIMEOUT_MS: z.string().default(String(TIMEOUT_DEFAULTS_MS.mempalaceRemoteMine)).transform((value) => Number.parseInt(value, 10)).refine((value) => Number.isFinite(value) && value > 0, "MEMPALACE_REMOTE_MINE_TIMEOUT_MS must be a positive number"),
   MEMPALACE_REMOTE_MINE_BATCH_SIZE: z.string().default("0").transform((value) => Number.parseInt(value, 10)).refine((value) => Number.isFinite(value) && value >= 0, "MEMPALACE_REMOTE_MINE_BATCH_SIZE must be a non-negative number"),
 });
 
@@ -187,6 +211,8 @@ export const appConfig = {
   threadAutoArchiveMinutes: normalizeArchiveDuration(rawConfig.THREAD_AUTO_ARCHIVE_MINUTES),
   askConcurrencyPerGuild: rawConfig.ASK_CONCURRENCY_PER_GUILD,
   askExecutionTimeoutMs: rawConfig.ASK_EXECUTION_TIMEOUT_MS,
+  providerIdleTimeoutMs: rawConfig.PROVIDER_IDLE_TIMEOUT_MS,
+  reviewerTimeoutMs: rawConfig.REVIEWER_TIMEOUT_MS,
   iterativeVerificationTimeoutMs: rawConfig.ITERATIVE_VERIFICATION_TIMEOUT_MS,
   reviewConcurrency: rawConfig.REVIEW_CONCURRENCY,
   installStepTimeoutMs: rawConfig.INSTALL_STEP_TIMEOUT_MS,

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -2964,6 +2964,7 @@ Output the result of the command or the link to the created issue.`;
       prompt: input.prompt,
       cwd: input.cwd,
       timeoutMs: input.timeoutMs ?? this.config.askExecutionTimeoutMs,
+      idleTimeoutMs: this.config.providerIdleTimeoutMs,
       ...(input.model ? { model: input.model } : {}),
       ...(input.env ? { env: input.env } : {})
     };
@@ -3157,6 +3158,7 @@ Output the result of the command or the link to the created issue.`;
               judge: runners.judge,
               summarizer: runners.summarizer,
               stageTimeoutMs: this.config.askExecutionTimeoutMs,
+              reviewerTimeoutMs: this.config.reviewerTimeoutMs,
               totalTimeoutMs: this.config.askExecutionTimeoutMs * 2,
               reviewConcurrency: this.config.reviewConcurrency,
               maxConsensusRounds: this.getReviewRounds(interaction.guildId!),

--- a/src/services/adversarialReviewService.ts
+++ b/src/services/adversarialReviewService.ts
@@ -643,6 +643,8 @@ export async function runAdversarialReview(input: {
   judge: ReviewModelRunner;
   summarizer: ReviewModelRunner;
   stageTimeoutMs: number;
+  /** Fixed cap for each primary reviewer invocation in each consensus round. */
+  reviewerTimeoutMs?: number;
   totalTimeoutMs: number;
   reviewConcurrency?: number;
   maxConsensusRounds?: number;
@@ -700,6 +702,7 @@ export async function runAdversarialReview(input: {
       judge: { provider: input.judge.provider, model: input.judge.model ?? null, label: input.judge.label },
       summarizer: { provider: input.summarizer.provider, model: input.summarizer.model ?? null },
       stageTimeoutMs: input.stageTimeoutMs,
+      reviewerTimeoutMs: input.reviewerTimeoutMs ?? input.stageTimeoutMs,
       totalTimeoutMs: input.totalTimeoutMs,
       reviewConcurrency,
       maxConsensusRounds
@@ -733,11 +736,6 @@ export async function runAdversarialReview(input: {
     for (let round = 1; round <= maxConsensusRounds; round += 1) {
       checkBudget();
       await emitProgress({ type: "round-start", round, maxRounds: maxConsensusRounds });
-      // When reviewConcurrency serializes a fan-out stage, that stage occupies
-      // as many sequential budget slots as it has batches — without this
-      // weighting, a serialized reviewer stage could consume nearly the whole
-      // remaining budget and starve the critique/judge/summarizer stages.
-      const reviewerBatches = Math.ceil(activeReviewers.length / reviewConcurrency);
       const reviewerResults = await mapSettledWithConcurrency(
         activeReviewers,
         reviewConcurrency,
@@ -768,9 +766,9 @@ export async function runAdversarialReview(input: {
             cwd: input.worktreePath,
             timeoutMs: getStageTimeout(
               startTime,
-              input.stageTimeoutMs,
+              input.reviewerTimeoutMs ?? input.stageTimeoutMs,
               input.totalTimeoutMs,
-              (maxConsensusRounds - round + 1) * (2 * reviewerBatches + 1) + 1
+              1
             ),
             ...(reviewer.model ? { model: reviewer.model } : {})
           });

--- a/src/utils/runProviderRequest.ts
+++ b/src/utils/runProviderRequest.ts
@@ -5,6 +5,7 @@ export interface ProviderRequestInput {
   prompt: string;
   cwd: string;
   timeoutMs: number;
+  idleTimeoutMs?: number;
   model?: string;
   env?: NodeJS.ProcessEnv;
 }
@@ -163,6 +164,7 @@ export async function runProviderRequest(
       const result = await spawnCollect(config.binary, stdinArgs, {
         cwd: input.cwd,
         timeoutMs: input.timeoutMs,
+        ...(input.idleTimeoutMs !== undefined ? { idleTimeoutMs: Math.min(input.idleTimeoutMs, input.timeoutMs) } : {}),
         maxBuffer: 4 * 1024 * 1024,
         ...(input.env ? { env: input.env } : {}),
         stdin: input.prompt,
@@ -175,6 +177,7 @@ export async function runProviderRequest(
         promptArgIndices,
         cwd: input.cwd,
         timeoutMs: input.timeoutMs,
+        ...(input.idleTimeoutMs !== undefined ? { idleTimeoutMs: Math.min(input.idleTimeoutMs, input.timeoutMs) } : {}),
         maxBuffer: 4 * 1024 * 1024,
         logger,
         logLabel: config.logLabel,

--- a/src/utils/spawnCollect.ts
+++ b/src/utils/spawnCollect.ts
@@ -303,6 +303,8 @@ export interface SpawnCollectTransportOptions {
   cwd: string;
   /** Kill the process after this many milliseconds. */
   timeoutMs: number;
+  /** Kill the process if neither stdout nor stderr has produced data for this long. */
+  idleTimeoutMs?: number;
   /** Hard limit for stdout in bytes. */
   maxBuffer: number;
   /** Soft limit for stderr in bytes (default 64 KB). */
@@ -346,6 +348,7 @@ export interface SpawnCollectTransportOptions {
 function buildOptions(base: {
   cwd: string;
   timeoutMs: number;
+  idleTimeoutMs?: number;
   maxBuffer: number;
   maxStderrBuffer?: number;
   env?: NodeJS.ProcessEnv;
@@ -357,6 +360,7 @@ function buildOptions(base: {
     maxBuffer: base.maxBuffer,
   };
   if (base.maxStderrBuffer !== undefined) opts.maxStderrBuffer = base.maxStderrBuffer;
+  if (base.idleTimeoutMs !== undefined) opts.idleTimeoutMs = base.idleTimeoutMs;
   if (base.env !== undefined) opts.env = base.env;
   if (base.stdin !== undefined) opts.stdin = base.stdin;
   return opts;
@@ -384,6 +388,7 @@ export async function spawnCollectWithTransport(
     promptArgIndices,
     cwd,
     timeoutMs,
+    idleTimeoutMs,
     maxBuffer,
     maxStderrBuffer,
     env,
@@ -445,6 +450,7 @@ export async function spawnCollectWithTransport(
           );
       return await spawnCollect(file, fileArgs, buildOptions({
         cwd, timeoutMs, maxBuffer,
+        ...(idleTimeoutMs !== undefined ? { idleTimeoutMs } : {}),
         ...(maxStderrBuffer !== undefined ? { maxStderrBuffer } : {}),
         ...(env !== undefined ? { env } : {}),
       }));
@@ -452,6 +458,7 @@ export async function spawnCollectWithTransport(
 
     return await spawnCollect(file, decision.args, buildOptions({
       cwd, timeoutMs, maxBuffer,
+      ...(idleTimeoutMs !== undefined ? { idleTimeoutMs } : {}),
       ...(maxStderrBuffer !== undefined ? { maxStderrBuffer } : {}),
       ...(env !== undefined ? { env } : {}),
       ...(decision.stdinPayload !== undefined ? { stdin: decision.stdinPayload } : {}),
@@ -470,6 +477,8 @@ export interface SpawnResult {
 
 const DEFAULT_STDERR_MAX = 64 * 1024; // 64 KB
 
+export type SpawnTimeoutReason = "idle" | "absolute";
+
 /**
  * Spawns a child process, collects stdout/stderr, and resolves/rejects on close.
  * stdin is set to "ignore" to prevent CLIs from blocking on interactive input.
@@ -483,7 +492,17 @@ const DEFAULT_STDERR_MAX = 64 * 1024; // 64 KB
 export function spawnCollect(
   file: string,
   args: string[],
-  options: { cwd: string; timeoutMs: number; maxBuffer: number; maxStderrBuffer?: number; env?: NodeJS.ProcessEnv; stdin?: string }
+  options: {
+    cwd: string;
+    /** Absolute upper bound, regardless of output activity. */
+    timeoutMs: number;
+    /** Kill a process that has produced no stdout or stderr for this long. */
+    idleTimeoutMs?: number;
+    maxBuffer: number;
+    maxStderrBuffer?: number;
+    env?: NodeJS.ProcessEnv;
+    stdin?: string;
+  }
 ): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {
     const child = spawn(file, args, {
@@ -500,19 +519,38 @@ export function spawnCollect(
 
     let stdout = "";
     let stderr = "";
-    let timedOut = false;
+    let timeoutReason: SpawnTimeoutReason | undefined;
     let bufferOverflow = false;
     let stderrTruncated = false;
 
     const effectiveStderrMax = options.maxStderrBuffer ?? DEFAULT_STDERR_MAX;
 
-    const timer = setTimeout(() => {
-      timedOut = true;
+    const absoluteTimer = setTimeout(() => {
+      if (timeoutReason) return;
+      timeoutReason = "absolute";
       child.kill("SIGTERM");
     }, options.timeoutMs);
 
+    let idleTimer: NodeJS.Timeout | undefined;
+    const resetIdleTimer = () => {
+      if (options.idleTimeoutMs === undefined) return;
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        if (timeoutReason) return;
+        timeoutReason = "idle";
+        child.kill("SIGTERM");
+      }, options.idleTimeoutMs);
+    };
+    resetIdleTimer();
+
+    const clearTimers = () => {
+      clearTimeout(absoluteTimer);
+      if (idleTimer) clearTimeout(idleTimer);
+    };
+
     child.stdout!.on("data", (chunk: Buffer) => {
-      if (bufferOverflow || timedOut) return;
+      if (bufferOverflow || timeoutReason) return;
+      resetIdleTimer();
       stdout += chunk.toString();
       if (stdout.length > options.maxBuffer) {
         bufferOverflow = true;
@@ -521,7 +559,8 @@ export function spawnCollect(
     });
 
     child.stderr!.on("data", (chunk: Buffer) => {
-      if (bufferOverflow || timedOut) return;
+      if (bufferOverflow || timeoutReason) return;
+      resetIdleTimer();
       const combined = stderr + chunk.toString();
       if (combined.length > effectiveStderrMax) {
         stderrTruncated = true;
@@ -532,12 +571,12 @@ export function spawnCollect(
     });
 
     child.on("error", (err) => {
-      clearTimeout(timer);
+      clearTimers();
       reject(err);
     });
 
     child.on("close", (code, signal) => {
-      clearTimeout(timer);
+      clearTimers();
       const finalStderr = stderrTruncated ? `[stderr truncated]\n${stderr}` : stderr;
 
       if (bufferOverflow) {
@@ -546,15 +585,18 @@ export function spawnCollect(
         }));
         return;
       }
-      if (timedOut) {
+      if (timeoutReason) {
+        const timeoutMessage = timeoutReason === "idle"
+          ? `Process produced no stdout or stderr for ${options.idleTimeoutMs}ms`
+          : `Process timed out after ${options.timeoutMs}ms`;
         if (code !== null) {
-          reject(Object.assign(new Error(`Process exited with code ${String(code)} after timeout`), {
-            code: "ETIMEDOUT", killed: false, signal, stdout, stderr: finalStderr,
+          reject(Object.assign(new Error(`Process exited with code ${String(code)} after timeout: ${timeoutMessage}`), {
+            code: "ETIMEDOUT", timeoutReason, killed: false, signal, stdout, stderr: finalStderr,
           }));
           return;
         }
-        reject(Object.assign(new Error(`Process timed out after ${options.timeoutMs}ms`), {
-          code: "ETIMEDOUT", killed: true, signal, stdout, stderr: finalStderr,
+        reject(Object.assign(new Error(timeoutMessage), {
+          code: "ETIMEDOUT", timeoutReason, killed: true, signal, stdout, stderr: finalStderr,
         }));
         return;
       }

--- a/tests/adversarialReviewService.test.ts
+++ b/tests/adversarialReviewService.test.ts
@@ -179,18 +179,17 @@ describe("adversarialReviewService", () => {
         judge,
         summarizer,
         stageTimeoutMs: 1_000,
+        reviewerTimeoutMs: 500,
         totalTimeoutMs: 900,
         maxConsensusRounds: 1
       });
 
-      // Default reviewConcurrency (1) serializes the two reviewers, so the
-      // fan-out stages count one budget slot per batch: the review stage
-      // divides the 900ms budget by 6 and the critique stage by 4, keeping the
-      // serialized stages from starving the judge and summarizer.
+      // Each primary reviewer receives its configured fixed budget. The
+      // remaining stages continue to divide the overall review budget.
       expect(timeouts).toEqual([
         { label: "analyzer", timeoutMs: 300 },
-        { label: "reviewer-1", timeoutMs: 150 },
-        { label: "reviewer-2", timeoutMs: 150 },
+        { label: "reviewer-1", timeoutMs: 500 },
+        { label: "reviewer-2", timeoutMs: 500 },
         { label: "reviewer-1", timeoutMs: 225 },
         { label: "reviewer-2", timeoutMs: 225 },
         { label: "judge", timeoutMs: 450 },

--- a/tests/spawnCollect.test.ts
+++ b/tests/spawnCollect.test.ts
@@ -108,6 +108,37 @@ describe("spawnCollect — stderr trimming", () => {
       stderr: expect.stringMatching(/^\[stderr truncated\]\n/),
     });
   });
+
+  it("kills a silent process when its inactivity timeout expires before its absolute timeout", async () => {
+    const error = await spawnCollect(
+      node,
+      ["-e", "setTimeout(() => {}, 60_000);"],
+      { cwd, timeoutMs: 1_000, idleTimeoutMs: 100, maxBuffer: 1024 },
+    ).catch((reason: unknown) => reason);
+
+    expect(error).toMatchObject({ code: "ETIMEDOUT", timeoutReason: "idle" });
+  });
+
+  it("resets the inactivity timeout when either output stream produces data", async () => {
+    const result = await spawnCollect(
+      node,
+      ["-e", "let count = 0; const timer = setInterval(() => { (count++ % 2 ? process.stderr : process.stdout).write('x'); if (count === 6) { clearInterval(timer); } }, 50);"],
+      { cwd, timeoutMs: 1_000, idleTimeoutMs: 120, maxBuffer: 1024 },
+    );
+
+    expect(result.stdout).toBe("xxx");
+    expect(result.stderr).toBe("xxx");
+  });
+
+  it("still enforces the absolute timeout while a process keeps producing output", async () => {
+    const error = await spawnCollect(
+      node,
+      ["-e", "setInterval(() => process.stdout.write('x'), 20);"],
+      { cwd, timeoutMs: 180, idleTimeoutMs: 100, maxBuffer: 1024 },
+    ).catch((reason: unknown) => reason);
+
+    expect(error).toMatchObject({ code: "ETIMEDOUT", timeoutReason: "absolute" });
+  });
 });
 
 describe("spawnCollectWithTransport — argv transport", () => {


### PR DESCRIPTION
## Summary
- Add resettable inactivity timeouts based on stdout/stderr activity.
- Keep absolute provider caps, with a 90-minute default for provider invocations.
- Give each primary reviewer a fixed 20-minute cap per consensus round.
- Centralize timeout defaults and document all environment overrides.

## Why
Previously, reviewer and iterative provider calls could be terminated by dynamically divided budgets even while making progress. Silent processes now stop after 15 minutes, while active processes can continue up to their applicable absolute cap.

## Validation
- `npm run check`
- `npm test -- tests/adversarialReviewService.test.ts tests/spawnCollect.test.ts`
- 38 focused tests passed.