### PR TITLE
fix: raise container pids limit default from 256 to 1024

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     mem_limit: ${ACTUARIUS_CONTAINER_MEMORY:-700m}
     memswap_limit: ${ACTUARIUS_CONTAINER_MEMORY_SWAP:-2g}
     cpus: ${ACTUARIUS_CONTAINER_CPUS:-0.8}
-    pids_limit: ${ACTUARIUS_CONTAINER_PIDS_LIMIT:-256}
+    pids_limit: ${ACTUARIUS_CONTAINER_PIDS_LIMIT:-1024}
     restart: unless-stopped
 
 volumes:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -74,8 +74,11 @@ sudo reboot
 4. Starts a new container with the correct env vars mapped from metadata
 
 Production deploys constrain the container to 700 MB RAM, 2 GB memory+swap,
-0.8 CPU, and 256 processes by default. These cgroup limits keep provider builds
-or fork storms from starving the VM host. The swap allowance matters: the VM
+0.8 CPU, and 1024 tasks by default. These cgroup limits keep provider builds
+or fork storms from starving the VM host. Note the pids limit counts threads
+as well as processes — each concurrent provider CLI stack uses roughly 60–80
+tasks, so the earlier 256 default caused `EAGAIN` (os error 11) thread-creation
+failures when three reviewers ran at once. The swap allowance matters: the VM
 provisions a 1536 MB swapfile (`infra/startup.sh`) so heavy provider CLI
 subprocesses spill to swap instead of being SIGKILLed by the OOM killer.
 Override the limits with Terraform variables `container_memory`,

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -12,7 +12,7 @@ ask_concurrency   = 1
 container_memory  = "700m"
 container_memory_swap = "2g"   # memory+swap total; equal to container_memory disables swap
 container_cpus    = "0.8"
-container_pids_limit = 256
+container_pids_limit = 1024
 
 # Discord application config (IDs are not secrets; the bot token is — see below)
 discord_client_id = "replace_me"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -47,8 +47,8 @@ variable "container_cpus" {
 
 variable "container_pids_limit" {
   type        = number
-  description = "Maximum process count inside the Actuarius container."
-  default     = 256
+  description = "Maximum task count (processes AND threads) inside the Actuarius container. Each concurrent provider CLI stack uses ~60-80 tasks; 256 caused EAGAIN thread-creation failures during 3-reviewer reviews."
+  default     = 1024
 }
 
 # Secret values (Discord token, GitHub App private key, Claude OAuth token,

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -58,7 +58,10 @@ CONTAINER_MEMORY="${CONTAINER_MEMORY:-700m}"
 # being OOM-killed; 2g leaves the host ~230M of swap headroom.
 CONTAINER_MEMORY_SWAP="${CONTAINER_MEMORY_SWAP:-2g}"
 CONTAINER_CPUS="${CONTAINER_CPUS:-0.8}"
-CONTAINER_PIDS_LIMIT="${CONTAINER_PIDS_LIMIT:-256}"
+# Pids limit counts tasks (threads included), not just processes. Each
+# concurrent provider CLI stack uses ~60-80 tasks; 256 caused EAGAIN
+# thread-creation failures when a 3-reviewer review ran.
+CONTAINER_PIDS_LIMIT="${CONTAINER_PIDS_LIMIT:-1024}"
 
 # Docker requires --memory-swap >= --memory (it is the memory+swap TOTAL).
 # If a larger memory override predates the swap knob, raise the swap total to

--- a/tests/redeployScript.test.ts
+++ b/tests/redeployScript.test.ts
@@ -169,7 +169,7 @@ describe("scripts/redeploy.sh auth validation", () => {
     expect(result.dockerLog).toContain("--memory\n700m");
     expect(result.dockerLog).toContain("--memory-swap\n2g");
     expect(result.dockerLog).toContain("--cpus\n0.8");
-    expect(result.dockerLog).toContain("--pids-limit\n256");
+    expect(result.dockerLog).toContain("--pids-limit\n1024");
   });
 
   it("forwards configured container resource limits", () => {


### PR DESCRIPTION
## Problem

Production provider subprocesses are dying with `EAGAIN` (os error 11) on thread creation:

- **Review run 93 / request 958** (2026-07-11 04:31Z): all three reviewers failed simultaneously — Codex exited 1 with `Resource temporarily unavailable (os error 11)`, OpenCode died with SIGABRT, the third exited null → `INSUFFICIENT_REVIEWERS`.
- **Request 961 `/revise`** (2026-07-11 09:24Z): the Codex CLI panicked at startup (`creating threadpool failed: ThreadPoolBuildError ... WouldBlock`) and sat silent until the 10-minute iterative timeout killed it.

## Root cause

The container runs with `--pids-limit 256`, and the cgroup pids controller counts **tasks (threads included)**, not just processes. Each concurrent provider CLI stack — Node wrapper (~12-15 threads) + Rust CLI thread pools sized for the host CPUs + git subprocesses — uses roughly 60-80 tasks. Three reviewers plus the bot itself brushes the 256 ceiling, and `clone()` fails with EAGAIN. This also explains why the kernel logs show **no OOM events**: a pids ceiling fails silently, unlike memory exhaustion.

## Change

Raise the default from 256 to 1024 in all defaulting layers (docker-compose, redeploy.sh fallback, Terraform variable, tfvars example) and update docs/deploy.md. 1024 keeps the fork-storm protection intent while giving three concurrent CLI stacks real headroom.

## Deployment note — merge alone does NOT fix prod

`redeploy.sh` reads the limit from VM metadata, and the live instance currently has `env-container-pids-limit: 256` pinned. After merging, a `terraform apply` is required to update the metadata (or update it manually), then redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)