### PR TITLE
Add OpenAI subscription auth for OpenCode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ REVIEW_CONCURRENCY=1
 # Required for Gemini execution when ENABLE_GEMINI_EXECUTION=true
 # GEMINI_API_KEY=replace_me
 # Required for OpenCode execution when ENABLE_OPENCODE_EXECUTION=true.
-# Set DEEPSEEK_API_KEY or use /opencode-auth to configure per-guild keys.
+# Set DEEPSEEK_API_KEY, use /opencode-auth for API keys, or /auth-openai-opencode for ChatGPT Pro/Plus.
 # OpenCode supports any provider/model via --model <provider>/<model>.
 # DEEPSEEK_API_KEY=replace_me
 # OPENAI_API_KEY=replace_me

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Discord bot container that links GitHub repos to Discord channels and creates re
 - Runs the configured AI provider (Claude, Codex, Gemini, or OpenCode) for each `/ask` request in an isolated git worktree.
 - Queues `/ask` jobs with bounded per-guild concurrency and support for `/review` (adversarial code review across multiple provider CLIs).
 - Stores guild/repo/request mappings in SQLite.
-- Supports `/opencode-auth` for per-provider API key management when using OpenCode as the provider.
+- Supports `/auth-openai-opencode` for ChatGPT Pro/Plus subscription login and `/opencode-auth` for per-provider API key management when using OpenCode as the provider.
 
 ## What v1 does not do
 
@@ -56,7 +56,7 @@ Copy `.env.example` to `.env` and set:
 - `ENABLE_GEMINI_EXECUTION` (default `false`, enables Gemini provider)
 - `ENABLE_OPENCODE_EXECUTION` (default `false`, enables OpenCode/DeepSeek provider)
 - `GEMINI_API_KEY` (required for Gemini execution)
-- `DEEPSEEK_API_KEY` (required for OpenCode execution when not using `/opencode-auth`)
+- `DEEPSEEK_API_KEY` (required for OpenCode execution when not using stored OpenCode credentials)
 - `CLAUDE_CODE_OAUTH_TOKEN` (optional for local/manual runs, required by the production redeploy helper for non-interactive Claude auth)
 - `MEMPALACE_ENABLED` (default `false`, enables the local MemPalace MCP for agents)
 - `MEMPALACE_REMOTE_ENABLED` (default `false`, starts Actuarius' loopback MemPalace federation server and routes repo memory through it)
@@ -73,7 +73,7 @@ All timeout defaults live together in [`TIMEOUT_DEFAULTS_MS`](src/config.ts) and
 - `INSTALL_STEP_TIMEOUT_MS` — tool-install step cap (default `3600000`)
 - `MEMPALACE_REMOTE_TIMEOUT_MS` and `MEMPALACE_REMOTE_MINE_TIMEOUT_MS` — remote request and mine-operation caps (defaults `5000` and `2700000`)
 
-Provider CLI auth state is persisted under `/data/home/appuser` inside the container. The provider CLIs themselves are also installed under `/data/home/appuser/.npm-global`, with `docker/entrypoint.sh` seeding them on first boot if missing. That keeps Claude and Codex authentication and CLI updates across container replacement, because production mounts `/data` from the persistent disk. Gemini and OpenCode execution use API keys instead of persisted OAuth state — set `GEMINI_API_KEY` / `DEEPSEEK_API_KEY` as env vars, or use `/opencode-auth` to store per-provider keys in `auth.json` with support for DeepSeek, OpenAI, Anthropic, Google, xAI, Groq, OpenRouter, and Together.
+Provider CLI auth state is persisted under `/data/home/appuser` inside the container. The provider CLIs themselves are also installed under `/data/home/appuser/.npm-global`, with `docker/entrypoint.sh` seeding them on first boot if missing. That keeps provider authentication and CLI updates across container replacement, because production mounts `/data` from the persistent disk. For OpenCode, use `/auth-openai-opencode` to connect a ChatGPT Pro/Plus subscription with OpenAI's device flow, `/opencode-auth` to store per-provider API keys in `auth.json`, or set provider API keys such as `DEEPSEEK_API_KEY` in the environment. `/opencode-auth` supports DeepSeek, OpenAI, Anthropic, Google, xAI, Groq, OpenRouter, and Together.
 
 Managed tool installs are validated against the filesystem before Actuarius adds
 their binaries or environment values to provider processes. Use `/uninstall`

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -67,7 +67,7 @@ import {
 import { ClaudeExecutionError, runClaudeRequest } from "../services/claudeExecutionService.js";
 import { CodexExecutionError, runCodexRequest } from "../services/codexExecutionService.js";
 import { GeminiExecutionError, runGeminiRequest } from "../services/geminiExecutionService.js";
-import { OpencodeExecutionError, runOpencodeRequest, hasOpencodeAuth, OPENCODE_AUTH_PATH, ALLOWED_OPENCODE_PROVIDERS } from "../services/opencodeExecutionService.js";
+import { authenticateOpenAIOpencode, OpencodeExecutionError, runOpencodeRequest, hasOpencodeAuth, OPENCODE_AUTH_PATH, ALLOWED_OPENCODE_PROVIDERS } from "../services/opencodeExecutionService.js";
 import { RequestExecutionQueue } from "../services/requestExecutionQueue.js";
 import { InstallService, InstallServiceError } from "../services/installService.js";
 import { buildAptPackageId, getAptPackageSpec, isAptPackageId } from "../services/installerRegistry.js";
@@ -580,6 +580,7 @@ export class ActuariusBot {
   private readonly installService: InstallService;
   private readonly memPalace: MemPalaceClient | null;
   private readonly memPalaceRemote: MemPalaceRemoteService | null;
+  private opencodeOpenAIAuthInProgress = false;
 
   public constructor(
     config: AppConfig,
@@ -872,6 +873,9 @@ export class ActuariusBot {
         return;
       case "opencode-auth":
         await this.handleOpencodeAuth(interaction);
+        return;
+      case "auth-openai-opencode":
+        await this.handleAuthOpenAIOpenCode(interaction);
         return;
       case "opencode-auth-remove":
         await this.handleOpencodeAuthRemove(interaction);
@@ -1640,7 +1644,7 @@ export class ActuariusBot {
     }
 
     if (provider === "opencode" && !this.config.deepseekApiKey?.trim() && !(await hasOpencodeAuth())) {
-      return "OpenCode execution requires an API key. Use `/opencode-auth` to configure keys (e.g. `deepseek`, `openai`, `anthropic`), or set `DEEPSEEK_API_KEY` on the instance.";
+      return "OpenCode execution requires credentials. Use `/auth-openai-opencode` for a ChatGPT Pro/Plus subscription, `/opencode-auth` for an API key, or set `DEEPSEEK_API_KEY` on the instance.";
     }
 
     return null;
@@ -1900,6 +1904,76 @@ export class ActuariusBot {
     });
   }
 
+  private async handleAuthOpenAIOpenCode(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (!interaction.guild || !interaction.guildId) {
+      await interaction.reply({ content: "This command can only run in a Discord server.", ephemeral: true });
+      return;
+    }
+
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
+      await interaction.reply({
+        content: "You need the `Manage Server` permission to connect an OpenAI subscription to OpenCode.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    if (!this.config.enableOpencodeExecution) {
+      await interaction.reply({
+        content: "OpenCode execution is not enabled on this instance. Set `ENABLE_OPENCODE_EXECUTION=true` to enable it.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    if (this.opencodeOpenAIAuthInProgress) {
+      await interaction.reply({
+        content: "An OpenAI subscription authorization is already in progress. Complete it before starting another.",
+        ephemeral: true
+      });
+      return;
+    }
+
+    this.opencodeOpenAIAuthInProgress = true;
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+      await authenticateOpenAIOpencode({
+        cwd: process.cwd(),
+        onChallenge: ({ url, code }) => {
+          void interaction.editReply({
+            content: [
+              "OpenCode is waiting for your OpenAI authorization.",
+              "",
+              `[Open the OpenAI device login](${url}) and enter code \`${code}\`.`,
+              "",
+              "This private response will update automatically when authorization completes."
+            ].join("\n")
+          }).catch((err) => {
+            this.logger.warn({ err, guildId: interaction.guildId }, "Failed to show OpenCode OpenAI auth challenge");
+          });
+        }
+      });
+
+      this.logger.info({ guildId: interaction.guildId }, "OpenAI subscription connected to OpenCode");
+      await interaction.editReply({
+        content: "OpenAI ChatGPT Pro/Plus subscription connected to OpenCode. OpenAI models are now available to OpenCode requests."
+      });
+    } catch (err) {
+      this.logger.error({ err, guildId: interaction.guildId }, "OpenCode OpenAI subscription auth failed");
+      const error = err as Error & { code?: string; stderr?: string };
+      const diagnostic = (error.stderr?.trim() || error.message || "Unknown error")
+        .replace(/\u001b\[[0-?]*[ -/]*[@-~]/gu, "")
+        .slice(0, 1_400);
+      const message = error.code === "ETIMEDOUT"
+        ? "OpenAI authorization timed out. Run `/auth-openai-opencode` to try again."
+        : `OpenAI authorization failed: ${diagnostic}`;
+      await interaction.editReply({ content: message });
+    } finally {
+      this.opencodeOpenAIAuthInProgress = false;
+    }
+  }
+
   private async handleOpencodeAuthRemove(interaction: ChatInputCommandInteraction): Promise<void> {
     if (!interaction.guild || !interaction.guildId) {
       await interaction.reply({ content: "This command can only run in a Discord server.", ephemeral: true });
@@ -1908,7 +1982,7 @@ export class ActuariusBot {
 
     if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
       await interaction.reply({
-        content: "You need the `Manage Server` permission to remove OpenCode API keys.",
+        content: "You need the `Manage Server` permission to remove OpenCode credentials.",
         ephemeral: true
       });
       return;
@@ -1926,7 +2000,7 @@ export class ActuariusBot {
 
     if (!existsSync(OPENCODE_AUTH_PATH)) {
       await interaction.reply({
-        content: `No stored auth.json found. No keys to remove.`,
+        content: `No stored auth.json found. No credentials to remove.`,
         ephemeral: true
       });
       return;
@@ -1946,7 +2020,7 @@ export class ActuariusBot {
 
     if (!(rawProvider in authJson)) {
       await interaction.reply({
-        content: `No stored API key for **${rawProvider}**.`,
+        content: `No stored credential for **${rawProvider}**.`,
         ephemeral: true
       });
       return;
@@ -1963,7 +2037,7 @@ export class ActuariusBot {
     this.logger.info({ guildId: interaction.guildId, provider: rawProvider }, "OpenCode auth key removed");
 
     await interaction.reply({
-      content: `API key for **${rawProvider}** has been removed from OpenCode's auth.json.`,
+      content: `Credential for **${rawProvider}** has been removed from OpenCode's auth.json.`,
       ephemeral: true
     });
   }

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -1935,9 +1935,8 @@ export class ActuariusBot {
     }
 
     this.opencodeOpenAIAuthInProgress = true;
-    await interaction.deferReply({ ephemeral: true });
-
     try {
+      await interaction.deferReply({ ephemeral: true });
       await authenticateOpenAIOpencode({
         cwd: process.cwd(),
         onChallenge: ({ url, code }) => {
@@ -1956,9 +1955,13 @@ export class ActuariusBot {
       });
 
       this.logger.info({ guildId: interaction.guildId }, "OpenAI subscription connected to OpenCode");
-      await interaction.editReply({
-        content: "OpenAI ChatGPT Pro/Plus subscription connected to OpenCode. OpenAI models are now available to OpenCode requests."
-      });
+      try {
+        await interaction.editReply({
+          content: "OpenAI ChatGPT Pro/Plus subscription connected to OpenCode. OpenAI models are now available to OpenCode requests."
+        });
+      } catch (replyErr) {
+        this.logger.warn({ err: replyErr, guildId: interaction.guildId }, "Failed to send OpenAI auth success reply");
+      }
     } catch (err) {
       this.logger.error({ err, guildId: interaction.guildId }, "OpenCode OpenAI subscription auth failed");
       const error = err as Error & { code?: string; stderr?: string };
@@ -1968,7 +1971,11 @@ export class ActuariusBot {
       const message = error.code === "ETIMEDOUT"
         ? "OpenAI authorization timed out. Run `/auth-openai-opencode` to try again."
         : `OpenAI authorization failed: ${diagnostic}`;
-      await interaction.editReply({ content: message });
+      try {
+        await interaction.editReply({ content: message });
+      } catch (replyErr) {
+        this.logger.warn({ err: replyErr, guildId: interaction.guildId }, "Failed to send OpenAI auth failure reply");
+      }
     } finally {
       this.opencodeOpenAIAuthInProgress = false;
     }

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -1963,8 +1963,14 @@ export class ActuariusBot {
         this.logger.warn({ err: replyErr, guildId: interaction.guildId }, "Failed to send OpenAI auth success reply");
       }
     } catch (err) {
-      this.logger.error({ err, guildId: interaction.guildId }, "OpenCode OpenAI subscription auth failed");
       const error = err as Error & { code?: string; stderr?: string };
+      // spawnCollect errors can contain the device URL and one-time code in
+      // stdout/stderr. Log only non-sensitive classification fields.
+      this.logger.error({
+        guildId: interaction.guildId,
+        errorName: error.name,
+        ...(error.code ? { errorCode: error.code } : {})
+      }, "OpenCode OpenAI subscription auth failed");
       const diagnostic = (error.stderr?.trim() || error.message || "Unknown error")
         .replace(/\u001b\[[0-?]*[ -/]*[@-~]/gu, "")
         .slice(0, 1_400);

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -228,8 +228,11 @@ export const commandBuilders = [
         .setRequired(true)
     ),
   new SlashCommandBuilder()
+    .setName("auth-openai-opencode")
+    .setDescription("Connect a ChatGPT Pro/Plus subscription to OpenCode. Requires Manage Server permission."),
+  new SlashCommandBuilder()
     .setName("opencode-auth-remove")
-    .setDescription("Remove a stored API key for OpenCode. Requires Manage Server permission.")
+    .setDescription("Remove a stored OpenCode credential. Requires Manage Server permission.")
     .addStringOption((option) =>
       option
         .setName("provider")
@@ -318,6 +321,7 @@ export type CommandName =
   | "review-rounds"
   | "codex-auth"
   | "opencode-auth"
+  | "auth-openai-opencode"
   | "opencode-auth-remove"
   | "gh-auth-refresh"
   | "delete"

--- a/src/discord/messageTemplates.ts
+++ b/src/discord/messageTemplates.ts
@@ -19,6 +19,7 @@ export function buildHelpText(): string {
     "- `/model-current` Show the active AI provider, model, reviewer slots, and review role overrides for this server.",
     "- `/codex-auth credentials:<file>` Upload Codex credentials file from `~/.codex/auth.json` (admin only).",
     "- `/opencode-auth provider:<name> key:<your-key>` Configure an API key for OpenCode to use with a specific AI provider (admin only).",
+    "- `/auth-openai-opencode` Connect a ChatGPT Pro/Plus subscription to OpenCode (admin only).",
     "- `/opencode-auth-remove provider:<name>` Remove a stored API key for OpenCode (admin only).",
     "",
     "v1 notes:",
@@ -26,7 +27,7 @@ export function buildHelpText(): string {
     "- `/ask` uses queued AI execution with per-guild concurrency limits.",
     "- Codex and Gemini require `ENABLE_CODEX_EXECUTION` / `ENABLE_GEMINI_EXECUTION` to be enabled.",
     "- Gemini additionally requires `GEMINI_API_KEY`.",
-    "- OpenCode requires `ENABLE_OPENCODE_EXECUTION` and API keys. Use `/opencode-auth` to configure per-provider keys (deepseek, openai, anthropic, etc.) or set the relevant env vars on the instance.",
+    "- OpenCode requires `ENABLE_OPENCODE_EXECUTION` and credentials. Use `/auth-openai-opencode` for ChatGPT Pro/Plus, `/opencode-auth` for per-provider API keys, or set the relevant env vars on the instance.",
     "- OpenCode supports any provider/model combination via `--model <provider>/<model>`, e.g. `deepseek/deepseek-v4-pro`, `openai/o4-mini`, `anthropic/claude-sonnet-4-6`."
   ].join("\n");
 }

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -2,14 +2,17 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { stripVTControlCharacters } from "node:util";
 import type { Logger } from "pino";
 import { runProviderRequest } from "../utils/runProviderRequest.js";
+import { spawnCollect } from "../utils/spawnCollect.js";
 import { OPENCODE_TEMPFILE_DIRECTIVE } from "./llmPromptBuilders.js";
 
 export { OPENCODE_TEMPFILE_DIRECTIVE };
 
 export const ALLOWED_OPENCODE_PROVIDERS = ["deepseek", "openai", "anthropic", "google", "xai", "groq", "openrouter", "together"] as const;
 export const OPENCODE_AUTH_PATH = join(homedir(), ".local", "share", "opencode", "auth.json");
+const OPENAI_OPENCODE_AUTH_TIMEOUT_MS = 10 * 60 * 1000;
 
 // opencode's `-f/--file` flag "attaches file(s) to the message" rather than
 // replacing the message — so an oversized prompt delivered purely via --file
@@ -41,6 +44,70 @@ export class OpencodeExecutionError extends Error {
     super(message);
     this.name = "OpencodeExecutionError";
     this.code = code;
+  }
+}
+
+export interface OpenAIOpencodeAuthChallenge {
+  url: string;
+  code: string;
+}
+
+export interface OpenAIOpencodeAuthInput {
+  cwd: string;
+  onChallenge: (challenge: OpenAIOpencodeAuthChallenge) => void;
+  timeoutMs?: number;
+}
+
+export function parseOpenAIOpencodeAuthChallenge(output: string): OpenAIOpencodeAuthChallenge | null {
+  const normalized = stripVTControlCharacters(output);
+  const candidateUrls = normalized.match(/https:\/\/[^\s<>()]+/gu) ?? [];
+  const url = candidateUrls.find((candidate) => {
+    try {
+      const parsed = new URL(candidate);
+      return parsed.protocol === "https:" && parsed.hostname === "auth.openai.com" && parsed.pathname === "/codex/device";
+    } catch {
+      return false;
+    }
+  });
+  const code = /Enter code:\s*([A-Z0-9][A-Z0-9-]{3,})/iu.exec(normalized)?.[1];
+  return url && code ? { url, code } : null;
+}
+
+/**
+ * Starts OpenCode's device-code flow for a ChatGPT Pro/Plus subscription.
+ * The headless method is required because Actuarius normally runs remotely;
+ * browser OAuth redirects to localhost on the machine opening the link.
+ */
+export async function authenticateOpenAIOpencode(input: OpenAIOpencodeAuthInput): Promise<void> {
+  let challengeDelivered = false;
+
+  await spawnCollect(
+    "opencode",
+    [
+      "providers",
+      "login",
+      "--provider",
+      "OpenAI",
+      "--method",
+      "ChatGPT Pro/Plus (headless)"
+    ],
+    {
+      cwd: input.cwd,
+      timeoutMs: input.timeoutMs ?? OPENAI_OPENCODE_AUTH_TIMEOUT_MS,
+      maxBuffer: 256 * 1024,
+      maxStderrBuffer: 64 * 1024,
+      onOutput: ({ stdout, stderr }) => {
+        if (challengeDelivered) return;
+        const challenge = parseOpenAIOpencodeAuthChallenge(`${stdout}\n${stderr}`);
+        if (!challenge) return;
+        challengeDelivered = true;
+        input.onChallenge(challenge);
+      }
+    }
+  );
+
+  if (!challengeDelivered) {
+    throw new Error("OpenCode completed without providing an OpenAI device authorization challenge.");
   }
 }
 

--- a/src/services/opencodeExecutionService.ts
+++ b/src/services/opencodeExecutionService.ts
@@ -13,6 +13,7 @@ export { OPENCODE_TEMPFILE_DIRECTIVE };
 export const ALLOWED_OPENCODE_PROVIDERS = ["deepseek", "openai", "anthropic", "google", "xai", "groq", "openrouter", "together"] as const;
 export const OPENCODE_AUTH_PATH = join(homedir(), ".local", "share", "opencode", "auth.json");
 const OPENAI_OPENCODE_AUTH_TIMEOUT_MS = 10 * 60 * 1000;
+const OPENAI_OPENCODE_AUTH_MAX_BUFFER = 4 * 1024 * 1024;
 
 // opencode's `-f/--file` flag "attaches file(s) to the message" rather than
 // replacing the message — so an oversized prompt delivered purely via --file
@@ -73,6 +74,28 @@ export function parseOpenAIOpencodeAuthChallenge(output: string): OpenAIOpencode
   return url && code ? { url, code } : null;
 }
 
+async function hasSavedOpenAIOpencodeOAuthCredential(): Promise<boolean> {
+  try {
+    const raw = await readFile(OPENCODE_AUTH_PATH, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const credential = parsed.openai;
+    if (typeof credential !== "object" || credential === null || Array.isArray(credential)) {
+      return false;
+    }
+
+    const oauth = credential as Record<string, unknown>;
+    return oauth.type === "oauth"
+      && typeof oauth.access === "string"
+      && oauth.access.trim().length > 0
+      && typeof oauth.refresh === "string"
+      && oauth.refresh.trim().length > 0
+      && typeof oauth.expires === "number"
+      && Number.isFinite(oauth.expires);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Starts OpenCode's device-code flow for a ChatGPT Pro/Plus subscription.
  * The headless method is required because Actuarius normally runs remotely;
@@ -81,7 +104,7 @@ export function parseOpenAIOpencodeAuthChallenge(output: string): OpenAIOpencode
 export async function authenticateOpenAIOpencode(input: OpenAIOpencodeAuthInput): Promise<void> {
   let challengeDelivered = false;
 
-  await spawnCollect(
+  const result = await spawnCollect(
     "opencode",
     [
       "providers",
@@ -94,7 +117,9 @@ export async function authenticateOpenAIOpencode(input: OpenAIOpencodeAuthInput)
     {
       cwd: input.cwd,
       timeoutMs: input.timeoutMs ?? OPENAI_OPENCODE_AUTH_TIMEOUT_MS,
-      maxBuffer: 256 * 1024,
+      // Clack redraws its waiting spinner frequently for the entire device
+      // flow. Keep enough headroom for the full ten-minute timeout.
+      maxBuffer: OPENAI_OPENCODE_AUTH_MAX_BUFFER,
       maxStderrBuffer: 64 * 1024,
       onOutput: ({ stdout, stderr }) => {
         if (challengeDelivered) return;
@@ -108,6 +133,15 @@ export async function authenticateOpenAIOpencode(input: OpenAIOpencodeAuthInput)
 
   if (!challengeDelivered) {
     throw new Error("OpenCode completed without providing an OpenAI device authorization challenge.");
+  }
+
+  const output = stripVTControlCharacters(`${result.stdout}\n${result.stderr}`);
+  if (/Failed to authorize/iu.test(output)) {
+    throw new Error("OpenCode failed to authorize the OpenAI subscription.");
+  }
+
+  if (!(await hasSavedOpenAIOpencodeOAuthCredential())) {
+    throw new Error("OpenCode completed without saving a valid OpenAI OAuth credential.");
   }
 }
 

--- a/src/utils/spawnCollect.ts
+++ b/src/utils/spawnCollect.ts
@@ -529,6 +529,7 @@ export function spawnCollect(
     let timeoutReason: SpawnTimeoutReason | undefined;
     let bufferOverflow = false;
     let stderrTruncated = false;
+    let outputCallbackError: Error | undefined;
 
     const effectiveStderrMax = options.maxStderrBuffer ?? DEFAULT_STDERR_MAX;
 
@@ -555,11 +556,24 @@ export function spawnCollect(
       if (idleTimer) clearTimeout(idleTimer);
     };
 
+    const notifyOutput = (): void => {
+      if (!options.onOutput || outputCallbackError) return;
+      try {
+        options.onOutput({ stdout, stderr });
+      } catch (reason) {
+        outputCallbackError = reason instanceof Error
+          ? reason
+          : new Error("spawnCollect onOutput callback failed", { cause: reason });
+        child.kill("SIGTERM");
+      }
+    };
+
     child.stdout!.on("data", (chunk: Buffer) => {
-      if (bufferOverflow || timeoutReason) return;
+      if (bufferOverflow || timeoutReason || outputCallbackError) return;
       resetIdleTimer();
       stdout += chunk.toString();
-      options.onOutput?.({ stdout, stderr });
+      notifyOutput();
+      if (outputCallbackError) return;
       if (stdout.length > options.maxBuffer) {
         bufferOverflow = true;
         child.kill("SIGTERM");
@@ -567,7 +581,7 @@ export function spawnCollect(
     });
 
     child.stderr!.on("data", (chunk: Buffer) => {
-      if (bufferOverflow || timeoutReason) return;
+      if (bufferOverflow || timeoutReason || outputCallbackError) return;
       resetIdleTimer();
       const combined = stderr + chunk.toString();
       if (combined.length > effectiveStderrMax) {
@@ -576,7 +590,7 @@ export function spawnCollect(
       } else {
         stderr = combined;
       }
-      options.onOutput?.({ stdout, stderr });
+      notifyOutput();
     });
 
     child.on("error", (err) => {
@@ -588,6 +602,10 @@ export function spawnCollect(
       clearTimers();
       const finalStderr = stderrTruncated ? `[stderr truncated]\n${stderr}` : stderr;
 
+      if (outputCallbackError) {
+        reject(outputCallbackError);
+        return;
+      }
       if (bufferOverflow) {
         reject(Object.assign(new Error(`Process output exceeded maxBuffer (${options.maxBuffer} bytes)`), {
           code: "EMSGSIZE", killed: true, signal, stdout, stderr: finalStderr,

--- a/src/utils/spawnCollect.ts
+++ b/src/utils/spawnCollect.ts
@@ -475,6 +475,11 @@ export interface SpawnResult {
   stderr: string;
 }
 
+export interface SpawnOutputSnapshot {
+  stdout: string;
+  stderr: string;
+}
+
 const DEFAULT_STDERR_MAX = 64 * 1024; // 64 KB
 
 export type SpawnTimeoutReason = "idle" | "absolute";
@@ -502,6 +507,8 @@ export function spawnCollect(
     maxStderrBuffer?: number;
     env?: NodeJS.ProcessEnv;
     stdin?: string;
+    /** Called after stdout or stderr changes, with the output collected so far. */
+    onOutput?: (snapshot: SpawnOutputSnapshot) => void;
   }
 ): Promise<SpawnResult> {
   return new Promise((resolve, reject) => {
@@ -552,6 +559,7 @@ export function spawnCollect(
       if (bufferOverflow || timeoutReason) return;
       resetIdleTimer();
       stdout += chunk.toString();
+      options.onOutput?.({ stdout, stderr });
       if (stdout.length > options.maxBuffer) {
         bufferOverflow = true;
         child.kill("SIGTERM");
@@ -568,6 +576,7 @@ export function spawnCollect(
       } else {
         stderr = combined;
       }
+      options.onOutput?.({ stdout, stderr });
     });
 
     child.on("error", (err) => {

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -81,6 +81,7 @@ vi.mock("../src/services/opencodeExecutionService.js", async () => {
 
   return {
     ...actual,
+    authenticateOpenAIOpencode: vi.fn(),
     hasOpencodeAuth: vi.fn().mockResolvedValue(false)
   };
 });
@@ -124,6 +125,7 @@ const {
 const { spawnCollect } = await import("../src/utils/spawnCollect.js");
 const { listOpenIssues, viewIssueDetail } = await import("../src/services/githubService.js");
 const { runClaudeRequest } = await import("../src/services/claudeExecutionService.js");
+const { authenticateOpenAIOpencode } = await import("../src/services/opencodeExecutionService.js");
 const { runAdversarialReview } = await import("../src/services/adversarialReviewService.js");
 const { runIterativeTaskLoop } = await import("../src/services/iterativeTaskLoopService.js");
 const { createDraftPullRequest } = await import("../src/services/pullRequestService.js");
@@ -218,6 +220,47 @@ function createInteraction(overrides: Record<string, unknown> = {}) {
     ...overrides
   };
 }
+
+describe("ActuariusBot auth-openai-opencode command", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("runs the private headless device flow and reports success", async () => {
+    vi.mocked(authenticateOpenAIOpencode).mockImplementationOnce(async ({ onChallenge }) => {
+      onChallenge({ url: "https://auth.openai.com/codex/device", code: "ABCD-EFGH" });
+    });
+    const interaction = createInteraction({
+      memberPermissions: { has: vi.fn().mockReturnValue(true) }
+    });
+    const bot = createBot();
+    (bot as any).config.enableOpencodeExecution = true;
+
+    await (bot as any).handleAuthOpenAIOpenCode(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content: expect.stringContaining("https://auth.openai.com/codex/device")
+    });
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content: expect.stringContaining("subscription connected to OpenCode")
+    });
+  });
+
+  it("requires Manage Server permission", async () => {
+    const interaction = createInteraction();
+    const bot = createBot();
+    (bot as any).config.enableOpencodeExecution = true;
+
+    await (bot as any).handleAuthOpenAIOpenCode(interaction);
+
+    expect(authenticateOpenAIOpencode).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining("Manage Server"),
+      ephemeral: true
+    });
+  });
+});
 
 describe("ActuariusBot ask command", () => {
   beforeEach(() => {
@@ -2061,7 +2104,7 @@ describe("ActuariusBot review command", () => {
     await (bot as any).handleReview(interaction);
     expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
     expect(interaction.editReply).toHaveBeenCalledWith(
-      "**Provider unavailable** — slot 2 uses `opencode` which is not available. OpenCode execution requires an API key. Use `/opencode-auth` to configure keys (e.g. `deepseek`, `openai`, `anthropic`), or set `DEEPSEEK_API_KEY` on the instance."
+      "**Provider unavailable** — slot 2 uses `opencode` which is not available. OpenCode execution requires credentials. Use `/auth-openai-opencode` for a ChatGPT Pro/Plus subscription, `/opencode-auth` for an API key, or set `DEEPSEEK_API_KEY` on the instance."
     );
     expect(runAdversarialReview).not.toHaveBeenCalled();
   });

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -260,6 +260,56 @@ describe("ActuariusBot auth-openai-opencode command", () => {
       ephemeral: true
     });
   });
+
+  it("releases the auth lock when deferReply fails", async () => {
+    vi.mocked(authenticateOpenAIOpencode).mockResolvedValue(undefined);
+    const interaction = createInteraction({
+      memberPermissions: { has: vi.fn().mockReturnValue(true) },
+      deferReply: vi.fn()
+        .mockRejectedValueOnce(new Error("Discord unavailable"))
+        .mockResolvedValueOnce(undefined)
+    });
+    const bot = createBot();
+    (bot as any).config.enableOpencodeExecution = true;
+
+    await (bot as any).handleAuthOpenAIOpenCode(interaction);
+    await (bot as any).handleAuthOpenAIOpenCode(interaction);
+
+    expect(interaction.deferReply).toHaveBeenCalledTimes(2);
+    expect(authenticateOpenAIOpencode).toHaveBeenCalledOnce();
+    expect(interaction.reply).not.toHaveBeenCalledWith(expect.objectContaining({
+      content: expect.stringContaining("already in progress")
+    }));
+  });
+
+  it("does not misreport successful auth when the success reply fails", async () => {
+    vi.mocked(authenticateOpenAIOpencode).mockResolvedValueOnce(undefined);
+    const interaction = createInteraction({
+      memberPermissions: { has: vi.fn().mockReturnValue(true) },
+      editReply: vi.fn().mockRejectedValueOnce(new Error("Interaction token expired"))
+    });
+    const bot = createBot();
+    (bot as any).config.enableOpencodeExecution = true;
+
+    await expect((bot as any).handleAuthOpenAIOpenCode(interaction)).resolves.toBeUndefined();
+
+    expect(authenticateOpenAIOpencode).toHaveBeenCalledOnce();
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+  });
+
+  it("swallows a secondary reply failure after auth itself fails", async () => {
+    vi.mocked(authenticateOpenAIOpencode).mockRejectedValueOnce(new Error("Authorization failed"));
+    const interaction = createInteraction({
+      memberPermissions: { has: vi.fn().mockReturnValue(true) },
+      editReply: vi.fn().mockRejectedValueOnce(new Error("Interaction token expired"))
+    });
+    const bot = createBot();
+    (bot as any).config.enableOpencodeExecution = true;
+
+    await expect((bot as any).handleAuthOpenAIOpenCode(interaction)).resolves.toBeUndefined();
+
+    expect(interaction.editReply).toHaveBeenCalledOnce();
+  });
 });
 
 describe("ActuariusBot ask command", () => {

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -310,6 +310,37 @@ describe("ActuariusBot auth-openai-opencode command", () => {
 
     expect(interaction.editReply).toHaveBeenCalledOnce();
   });
+
+  it("does not include device authorization output in failure logs", async () => {
+    const deviceCode = "SECRET-DEVICE-CODE";
+    vi.mocked(authenticateOpenAIOpencode).mockRejectedValueOnce(Object.assign(
+      new Error("Process timed out"),
+      {
+        code: "ETIMEDOUT",
+        stdout: `Go to: https://auth.openai.com/codex/device Enter code: ${deviceCode}`,
+        stderr: `Waiting for authorization for ${deviceCode}`
+      }
+    ));
+    const interaction = createInteraction({
+      memberPermissions: { has: vi.fn().mockReturnValue(true) }
+    });
+    const errorLog = vi.spyOn(logger, "error");
+    const bot = createBot();
+    (bot as any).config.enableOpencodeExecution = true;
+
+    try {
+      await (bot as any).handleAuthOpenAIOpenCode(interaction);
+
+      expect(errorLog).toHaveBeenCalledWith({
+        guildId: "guild-1",
+        errorName: "Error",
+        errorCode: "ETIMEDOUT"
+      }, "OpenCode OpenAI subscription auth failed");
+      expect(JSON.stringify(errorLog.mock.calls)).not.toContain(deviceCode);
+    } finally {
+      errorLog.mockRestore();
+    }
+  });
 });
 
 describe("ActuariusBot ask command", () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -15,6 +15,15 @@ describe("command registration", () => {
     expect(names).not.toContain("gemini-oauth-file");
   });
 
+  it("registers /auth-openai-opencode for ChatGPT subscription login", () => {
+    const command = commandBuilders.find((builder) => builder.name === "auth-openai-opencode");
+    expect(command).toBeDefined();
+    expect(command!.toJSON()).toMatchObject({
+      name: "auth-openai-opencode",
+      description: "Connect a ChatGPT Pro/Plus subscription to OpenCode. Requires Manage Server permission."
+    });
+  });
+
   it("registers /model-select with role choices", () => {
     const command = commandBuilders.find((builder) => builder.name === "model-select");
     expect(command).toBeDefined();

--- a/tests/opencodeExecutionService.test.ts
+++ b/tests/opencodeExecutionService.test.ts
@@ -17,10 +17,17 @@ vi.mock("../src/utils/spawnCollect.js", async (importActual) => {
   };
 });
 
-const { spawnCollectWithTransport } = await import("../src/utils/spawnCollect.js");
+const { spawnCollect, spawnCollectWithTransport } = await import("../src/utils/spawnCollect.js");
+const mockSpawnCollect = vi.mocked(spawnCollect);
 const mockSpawnCollectWithTransport = vi.mocked(spawnCollectWithTransport);
 
-const { OpencodeExecutionError, runOpencodeRequest, OPENCODE_TEMPFILE_DIRECTIVE } = await import("../src/services/opencodeExecutionService.js");
+const {
+  authenticateOpenAIOpencode,
+  OpencodeExecutionError,
+  parseOpenAIOpencodeAuthChallenge,
+  runOpencodeRequest,
+  OPENCODE_TEMPFILE_DIRECTIVE
+} = await import("../src/services/opencodeExecutionService.js");
 
 const logger = pino({ level: "silent" });
 
@@ -56,6 +63,52 @@ describe("OpencodeExecutionError", () => {
   it("constructs with EMPTY_OUTPUT code", () => {
     const error = new OpencodeExecutionError("EMPTY_OUTPUT", "empty");
     expect(error.code).toBe("EMPTY_OUTPUT");
+  });
+});
+
+describe("authenticateOpenAIOpencode", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("parses the OpenAI device URL and code from ANSI output", () => {
+    expect(parseOpenAIOpencodeAuthChallenge(
+      "\u001b[34mGo to: https://auth.openai.com/codex/device\u001b[0m\nEnter code: ABCD-EFGH"
+    )).toEqual({
+      url: "https://auth.openai.com/codex/device",
+      code: "ABCD-EFGH"
+    });
+  });
+
+  it("runs OpenCode's headless ChatGPT subscription flow and streams the challenge", async () => {
+    mockSpawnCollect.mockImplementationOnce(async (_file, _args, options) => {
+      options.onOutput?.({
+        stdout: "Go to: https://auth.openai.com/codex/device\n",
+        stderr: "Enter code: WXYZ-1234\n"
+      });
+      return { stdout: "Authorization complete", stderr: "" };
+    });
+    const onChallenge = vi.fn();
+
+    await authenticateOpenAIOpencode({ cwd: "/app", timeoutMs: 1234, onChallenge });
+
+    expect(mockSpawnCollect).toHaveBeenCalledWith(
+      "opencode",
+      ["providers", "login", "--provider", "OpenAI", "--method", "ChatGPT Pro/Plus (headless)"],
+      expect.objectContaining({ cwd: "/app", timeoutMs: 1234, onOutput: expect.any(Function) })
+    );
+    expect(onChallenge).toHaveBeenCalledOnce();
+    expect(onChallenge).toHaveBeenCalledWith({
+      url: "https://auth.openai.com/codex/device",
+      code: "WXYZ-1234"
+    });
+  });
+
+  it("fails when OpenCode exits without emitting a device challenge", async () => {
+    mockSpawnCollect.mockResolvedValueOnce({ stdout: "Authorization complete", stderr: "" });
+
+    await expect(authenticateOpenAIOpencode({ cwd: "/app", onChallenge: vi.fn() }))
+      .rejects.toThrow("without providing an OpenAI device authorization challenge");
   });
 });
 

--- a/tests/opencodeExecutionService.test.ts
+++ b/tests/opencodeExecutionService.test.ts
@@ -5,6 +5,11 @@ vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
 }));
 
+vi.mock("node:fs/promises", async (importActual) => ({
+  ...await importActual<typeof import("node:fs/promises")>(),
+  readFile: vi.fn(),
+}));
+
 // Mock only the process-spawning functions; keep the real (pure) byte-math
 // helpers like exceedsArgvLimits/estimateSpawnPayloadBytes and the size
 // constants so the transport decision runs for real.
@@ -18,8 +23,10 @@ vi.mock("../src/utils/spawnCollect.js", async (importActual) => {
 });
 
 const { spawnCollect, spawnCollectWithTransport } = await import("../src/utils/spawnCollect.js");
+const { readFile } = await import("node:fs/promises");
 const mockSpawnCollect = vi.mocked(spawnCollect);
 const mockSpawnCollectWithTransport = vi.mocked(spawnCollectWithTransport);
+const mockReadFile = vi.mocked(readFile);
 
 const {
   authenticateOpenAIOpencode,
@@ -69,6 +76,14 @@ describe("OpencodeExecutionError", () => {
 describe("authenticateOpenAIOpencode", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      openai: {
+        type: "oauth",
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: 1_800_000_000_000
+      }
+    }) as never);
   });
 
   it("parses the OpenAI device URL and code from ANSI output", () => {
@@ -95,7 +110,12 @@ describe("authenticateOpenAIOpencode", () => {
     expect(mockSpawnCollect).toHaveBeenCalledWith(
       "opencode",
       ["providers", "login", "--provider", "OpenAI", "--method", "ChatGPT Pro/Plus (headless)"],
-      expect.objectContaining({ cwd: "/app", timeoutMs: 1234, onOutput: expect.any(Function) })
+      expect.objectContaining({
+        cwd: "/app",
+        timeoutMs: 1234,
+        maxBuffer: 4 * 1024 * 1024,
+        onOutput: expect.any(Function)
+      })
     );
     expect(onChallenge).toHaveBeenCalledOnce();
     expect(onChallenge).toHaveBeenCalledWith({
@@ -109,6 +129,35 @@ describe("authenticateOpenAIOpencode", () => {
 
     await expect(authenticateOpenAIOpencode({ cwd: "/app", onChallenge: vi.fn() }))
       .rejects.toThrow("without providing an OpenAI device authorization challenge");
+  });
+
+  it("fails when OpenCode reports a failed authorization despite exiting normally", async () => {
+    mockSpawnCollect.mockImplementationOnce(async (_file, _args, options) => {
+      options.onOutput?.({
+        stdout: "Go to: https://auth.openai.com/codex/device\nEnter code: ABCD-EFGH\n",
+        stderr: ""
+      });
+      return { stdout: "Failed to authorize\nDone", stderr: "" };
+    });
+
+    await expect(authenticateOpenAIOpencode({ cwd: "/app", onChallenge: vi.fn() }))
+      .rejects.toThrow("failed to authorize the OpenAI subscription");
+  });
+
+  it("fails when OpenCode does not persist a valid OpenAI OAuth credential", async () => {
+    mockReadFile.mockResolvedValueOnce(JSON.stringify({
+      openai: { type: "oauth", access: "", refresh: "refresh-token", expires: 1_800_000_000_000 }
+    }) as never);
+    mockSpawnCollect.mockImplementationOnce(async (_file, _args, options) => {
+      options.onOutput?.({
+        stdout: "Go to: https://auth.openai.com/codex/device\nEnter code: ABCD-EFGH\n",
+        stderr: ""
+      });
+      return { stdout: "Login successful\nDone", stderr: "" };
+    });
+
+    await expect(authenticateOpenAIOpencode({ cwd: "/app", onChallenge: vi.fn() }))
+      .rejects.toThrow("without saving a valid OpenAI OAuth credential");
   });
 });
 

--- a/tests/spawnCollect.test.ts
+++ b/tests/spawnCollect.test.ts
@@ -139,6 +139,23 @@ describe("spawnCollect — stderr trimming", () => {
 
     expect(error).toMatchObject({ code: "ETIMEDOUT", timeoutReason: "absolute" });
   });
+
+  it.each(["stdout", "stderr"] as const)(
+    "rejects and terminates the child when an onOutput callback throws from %s",
+    async (stream) => {
+      const callbackError = new Error(`failed while handling ${stream}`);
+      const onOutput = vi.fn(() => { throw callbackError; });
+      const script = `${stream === "stdout" ? "process.stdout" : "process.stderr"}.write("chunk"); setInterval(() => {}, 60_000);`;
+
+      await expect(spawnCollect(
+        node,
+        ["-e", script],
+        { cwd, timeoutMs, maxBuffer: 1024, onOutput }
+      )).rejects.toBe(callbackError);
+
+      expect(onOutput).toHaveBeenCalledOnce();
+    }
+  );
 });
 
 describe("spawnCollectWithTransport — argv transport", () => {


### PR DESCRIPTION
## Summary

- add `/auth-openai-opencode` for connecting a ChatGPT Pro/Plus subscription to OpenCode
- run OpenCode's headless device authorization flow and stream the private login URL/code into Discord
- require Manage Server, prevent concurrent login attempts, and report success or timeout
- update OpenCode credential guidance, help text, README, environment documentation, and removal wording
- add focused service, command-registration, and bot-handler coverage

## Why

Actuarius normally runs in a remote container. OpenCode's browser login redirects to localhost, which resolves on the Discord user's machine rather than the Actuarius host. The headless device flow gives the user a portable URL and one-time code while OpenCode polls and persists the resulting OAuth credential in its existing auth store.

## Validation

- `npm run check`
- `npm run build`
- `npm test` — 646 passed, 10 skipped
- `git diff --check`