### PR TITLE
Add Jules PR review workflow

### DIFF
--- a/.github/workflows/jules-review.yml
+++ b/.github/workflows/jules-review.yml
@@ -9,13 +9,15 @@ concurrency:
 
 jobs:
   review:
+    # Fork PRs don't receive repo secrets — skip at the job level.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: read
       statuses: write
     steps:
-      - uses: DigitumDei/jules-pr-reviewer@main
+      - uses: DigitumDei/jules-pr-reviewer@v2
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/jules-review.yml
+++ b/.github/workflows/jules-review.yml
@@ -1,0 +1,22 @@
+name: Jules PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: jules-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      statuses: write
+    steps:
+      - uses: DigitumDei/jules-pr-reviewer@main
+        with:
+          jules_api_key: ${{ secrets.JULES_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on: blocking


### PR DESCRIPTION
Adds the Jules PR reviewer (private action DigitumDei/jules-pr-reviewer) to this repo. Reviews every non-draft, non-fork PR and posts findings as inline review comments, with a jules/review commit status gate on blocking findings.

Requires the JULES_API_KEY repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)