### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/jules-review.yml
+++ b/.github/workflows/jules-review.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - uses: DigitumDei/jules-pr-reviewer@v2
+      - uses: DigitumDei/jules-pr-reviewer@v2.1.0
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds Dependabot coverage for GitHub Actions. Since the Jules reviewer action now uses immutable version tags (no moving v2), this is what keeps the workflow reference current: Dependabot opens a bump PR here whenever a new release of DigitumDei/jules-pr-reviewer (or any other action used in workflows) is published. Weekly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)