### PR TITLE
Bump jules-pr-reviewer to v2.2.0

### DIFF
--- a/.github/workflows/jules-review.yml
+++ b/.github/workflows/jules-review.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - uses: DigitumDei/jules-pr-reviewer@v2.1.0
+      - uses: DigitumDei/jules-pr-reviewer@v2.2.0
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pins the Jules PR reviewer to the immutable v2.2.0 release tag (moving-tag scheme dropped for supply-chain hygiene).

v2.2.0 highlights: never stalls on agent questions (auto-nudge + VERDICT acceptance gate), skips Dependabot PRs before secret reads, excludes generated files/lockfiles from the review diff, reviews from the PR head checkout, injection-vs-data discrimination in the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)