### PR TITLE
Run MemPalace on the low_cpu embedding profile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,10 @@ REVIEW_CONCURRENCY=1
 # MEMPALACE_PALACE_PATH=/data/mempalace/palace
 # MEMPALACE_BINARY_PATH=/usr/local/bin/mempalace-mcp
 # MEMPALACE_CLI_PATH=/usr/local/bin/mempalace-cli
+# low_cpu (default) uses the quantized model and bounded ingest batches; balanced
+# uses the fp32 model with every runtime limit unbounded. Only raise to balanced
+# on a host with proven memory headroom.
+# MEMPALACE_EMBEDDING_PROFILE=low_cpu
 # MEMPALACE_REMOTE_ENABLED=true
 # MEMPALACE_REMOTE_PALACE_PATH=/data/mempalace/remote-palace
 # MEMPALACE_REMOTE_BIND=127.0.0.1:8765

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN curl -fsSL \
 ENV NODE_ENV=production
 ENV DATABASE_PATH=/data/app.db
 ENV MEMPALACE_PALACE_PATH=/data/mempalace/palace
+ENV MEMPALACE_EMBEDDING_PROFILE=low_cpu
 ENV HOME=/data/home/appuser
 ENV NPM_CONFIG_PREFIX=/data/home/appuser/.npm-global
 ENV PATH=/data/home/appuser/.npm-global/bin:$PATH
@@ -63,6 +64,7 @@ ENV APT_INSTALL_HELPER_PATH=/usr/local/bin/actuarius-apt-install
 COPY --from=deps /app/package.json ./package.json
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
+COPY config/opencode-plan-oc /app/config/opencode-plan-oc
 COPY docker/entrypoint.sh /app/entrypoint.sh
 COPY docker/install-llm-user-instructions.sh /app/install-llm-user-instructions.sh
 COPY docker/seed-provider-clis.sh /app/seed-provider-clis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ ENV APT_INSTALL_HELPER_PATH=/usr/local/bin/actuarius-apt-install
 COPY --from=deps /app/package.json ./package.json
 COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
-COPY config/opencode-plan-oc /app/config/opencode-plan-oc
 COPY docker/entrypoint.sh /app/entrypoint.sh
 COPY docker/install-llm-user-instructions.sh /app/install-llm-user-instructions.sh
 COPY docker/seed-provider-clis.sh /app/seed-provider-clis.sh

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ Copy `.env.example` to `.env` and set:
 - `MEMPALACE_REMOTE_URL` (default `http://127.0.0.1:8765`)
 - `MEMPALACE_REMOTE_TOKEN` (optional; generated and persisted if omitted)
 - `MEMPALACE_REMOTE_MINE_ON_SYNC` (default `true`, queues repo mining after connect/sync/checkouts)
+- `MEMPALACE_EMBEDDING_PROFILE` (default `low_cpu`; accepts `low_cpu` or `balanced`)
+
+MemPalace's own default profile is `balanced`, which loads the fp32 embedding model
+and leaves every runtime guardrail unbounded — ingest batch size, queue depth and
+worker threads are all uncapped, and the profile declares no RSS budget. Actuarius
+overrides this to `low_cpu` (quantized model, ingest batches of 8, single worker
+thread, 450 MB idle budget) because the production VM is a 1 GB e2-micro that
+otherwise OOM-kills provider processes. Only move to `balanced` on a host with
+proven memory headroom.
 
 All timeout defaults live together in [`TIMEOUT_DEFAULTS_MS`](src/config.ts) and can be overridden with these millisecond-valued environment variables:
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,22 +15,29 @@ fi
 
 MEMPALACE_BINARY_PATH="${MEMPALACE_BINARY_PATH:-/usr/local/bin/mempalace-mcp}"
 MEMPALACE_PALACE_PATH="${MEMPALACE_PALACE_PATH:-/data/mempalace/palace}"
+# Agent-spawned MCP servers do not reliably inherit the container environment,
+# so the profile is written into each client's server definition explicitly.
+MEMPALACE_EMBEDDING_PROFILE="${MEMPALACE_EMBEDDING_PROFILE:-low_cpu}"
 
 mkdir -p "$HOME/.gemini"
 if [ ! -f "$HOME/.gemini/settings.json" ]; then
   echo '{"security":{"auth":{"selectedType":"oauth-personal"}}}' > "$HOME/.gemini/settings.json"
 fi
 if [ -x "$MEMPALACE_BINARY_PATH" ]; then
-  python3 - "$HOME/.gemini/settings.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" <<'PYEOF'
+  python3 - "$HOME/.gemini/settings.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" "$MEMPALACE_EMBEDDING_PROFILE" <<'PYEOF'
 import json, sys
-path, binary, palace = sys.argv[1], sys.argv[2], sys.argv[3]
+path, binary, palace, profile = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 with open(path) as f: cfg = json.load(f)
 if "mcpServers" not in cfg:
     cfg["mcpServers"] = {}
 if "mempalace" not in cfg["mcpServers"]:
     cfg["mcpServers"]["mempalace"] = {
         "command": binary,
-        "env": {"MEMPALACE_PALACE_PATH": palace, "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"}
+        "env": {
+            "MEMPALACE_PALACE_PATH": palace,
+            "MEMPALACE_EMBEDDING_PROFILE": profile,
+            "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"
+        }
     }
     with open(path, "w") as f: json.dump(cfg, f, indent=2)
 PYEOF
@@ -38,16 +45,20 @@ fi
 
 if [ -x "$MEMPALACE_BINARY_PATH" ]; then
   if ! grep -q '"mempalace"' "$HOME/.claude.json" 2>/dev/null; then
-    python3 - "$HOME/.claude.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" <<'PYEOF'
+    python3 - "$HOME/.claude.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" "$MEMPALACE_EMBEDDING_PROFILE" <<'PYEOF'
 import json, sys, os
-path, binary, palace = sys.argv[1], sys.argv[2], sys.argv[3]
+path, binary, palace, profile = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 cfg = {}
 if os.path.exists(path):
     with open(path) as f: cfg = json.load(f)
 if "mcpServers" not in cfg: cfg["mcpServers"] = {}
 cfg["mcpServers"]["mempalace"] = {
     "command": binary,
-    "env": {"MEMPALACE_PALACE_PATH": palace, "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"}
+    "env": {
+        "MEMPALACE_PALACE_PATH": palace,
+        "MEMPALACE_EMBEDDING_PROFILE": profile,
+        "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"
+    }
 }
 with open(path, "w") as f: json.dump(cfg, f, indent=2)
 PYEOF
@@ -62,6 +73,7 @@ command = "$MEMPALACE_BINARY_PATH"
 
 [mcp_servers.mempalace.env]
 MEMPALACE_PALACE_PATH = "$MEMPALACE_PALACE_PATH"
+MEMPALACE_EMBEDDING_PROFILE = "$MEMPALACE_EMBEDDING_PROFILE"
 MEMPALACE_EMBED_ALLOW_DOWNLOADS = "1"
 EOF
   fi
@@ -69,9 +81,9 @@ EOF
   OPENCODE_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode"
   mkdir -p "$OPENCODE_CONFIG_DIR"
   if ! grep -q '"type"' "$OPENCODE_CONFIG_DIR/config.json" 2>/dev/null; then
-    python3 - "$OPENCODE_CONFIG_DIR/config.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" <<'PYEOF'
+    python3 - "$OPENCODE_CONFIG_DIR/config.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" "$MEMPALACE_EMBEDDING_PROFILE" <<'PYEOF'
 import json, sys, os
-path, binary, palace = sys.argv[1], sys.argv[2], sys.argv[3]
+path, binary, palace, profile = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 cfg = {}
 if os.path.exists(path):
     with open(path) as f: cfg = json.load(f)
@@ -80,7 +92,11 @@ cfg["mcp"]["mempalace"] = {
     "type": "local",
     "enabled": True,
     "command": [binary],
-    "environment": {"MEMPALACE_PALACE_PATH": palace, "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"}
+    "environment": {
+        "MEMPALACE_PALACE_PATH": palace,
+        "MEMPALACE_EMBEDDING_PROFILE": profile,
+        "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"
+    }
 }
 with open(path, "w") as f: json.dump(cfg, f, indent=2)
 PYEOF

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,84 +23,95 @@ mkdir -p "$HOME/.gemini"
 if [ ! -f "$HOME/.gemini/settings.json" ]; then
   echo '{"security":{"auth":{"selectedType":"oauth-personal"}}}' > "$HOME/.gemini/settings.json"
 fi
-if [ -x "$MEMPALACE_BINARY_PATH" ]; then
-  python3 - "$HOME/.gemini/settings.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" "$MEMPALACE_EMBEDDING_PROFILE" <<'PYEOF'
-import json, sys
-path, binary, palace, profile = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
-with open(path) as f: cfg = json.load(f)
-if "mcpServers" not in cfg:
-    cfg["mcpServers"] = {}
-if "mempalace" not in cfg["mcpServers"]:
-    cfg["mcpServers"]["mempalace"] = {
-        "command": binary,
-        "env": {
-            "MEMPALACE_PALACE_PATH": palace,
-            "MEMPALACE_EMBEDDING_PROFILE": profile,
-            "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"
-        }
-    }
-    with open(path, "w") as f: json.dump(cfg, f, indent=2)
-PYEOF
-fi
 
+# These registrations converge to the declared state on every start rather than
+# writing only when absent. $HOME is on the persistent data disk, so an upgraded
+# container finds MemPalace already registered from a previous image; a
+# write-if-absent guard would leave those stale definitions untouched and the
+# agents would keep launching MemPalace on whatever profile was baked in when
+# the entry was first written. Each writer is a no-op when the file already
+# matches, so repeated restarts do not churn the file.
 if [ -x "$MEMPALACE_BINARY_PATH" ]; then
-  if ! grep -q '"mempalace"' "$HOME/.claude.json" 2>/dev/null; then
-    python3 - "$HOME/.claude.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" "$MEMPALACE_EMBEDDING_PROFILE" <<'PYEOF'
-import json, sys, os
-path, binary, palace, profile = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
-cfg = {}
-if os.path.exists(path):
-    with open(path) as f: cfg = json.load(f)
-if "mcpServers" not in cfg: cfg["mcpServers"] = {}
-cfg["mcpServers"]["mempalace"] = {
-    "command": binary,
-    "env": {
-        "MEMPALACE_PALACE_PATH": palace,
-        "MEMPALACE_EMBEDDING_PROFILE": profile,
-        "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"
-    }
-}
-with open(path, "w") as f: json.dump(cfg, f, indent=2)
-PYEOF
-  fi
-
   mkdir -p "$HOME/.codex"
-  if ! grep -q '\[mcp_servers\.mempalace\]' "$HOME/.codex/config.toml" 2>/dev/null; then
-    cat <<EOF >> "$HOME/.codex/config.toml"
-
-[mcp_servers.mempalace]
-command = "$MEMPALACE_BINARY_PATH"
-
-[mcp_servers.mempalace.env]
-MEMPALACE_PALACE_PATH = "$MEMPALACE_PALACE_PATH"
-MEMPALACE_EMBEDDING_PROFILE = "$MEMPALACE_EMBEDDING_PROFILE"
-MEMPALACE_EMBED_ALLOW_DOWNLOADS = "1"
-EOF
-  fi
-
   OPENCODE_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode"
   mkdir -p "$OPENCODE_CONFIG_DIR"
-  if ! grep -q '"type"' "$OPENCODE_CONFIG_DIR/config.json" 2>/dev/null; then
-    python3 - "$OPENCODE_CONFIG_DIR/config.json" "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" "$MEMPALACE_EMBEDDING_PROFILE" <<'PYEOF'
-import json, sys, os
-path, binary, palace, profile = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
-cfg = {}
-if os.path.exists(path):
-    with open(path) as f: cfg = json.load(f)
-if "mcp" not in cfg: cfg["mcp"] = {}
-cfg["mcp"]["mempalace"] = {
-    "type": "local",
-    "enabled": True,
-    "command": [binary],
-    "environment": {
-        "MEMPALACE_PALACE_PATH": palace,
-        "MEMPALACE_EMBEDDING_PROFILE": profile,
-        "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1"
-    }
+
+  python3 - "$MEMPALACE_BINARY_PATH" "$MEMPALACE_PALACE_PATH" "$MEMPALACE_EMBEDDING_PROFILE" \
+    "$HOME/.gemini/settings.json" "$HOME/.claude.json" "$HOME/.codex/config.toml" \
+    "$OPENCODE_CONFIG_DIR/config.json" <<'PYEOF'
+import json, os, re, sys
+
+binary, palace, profile = sys.argv[1], sys.argv[2], sys.argv[3]
+gemini_path, claude_path, codex_path, opencode_path = sys.argv[4:8]
+
+env = {
+    "MEMPALACE_PALACE_PATH": palace,
+    "MEMPALACE_EMBEDDING_PROFILE": profile,
+    "MEMPALACE_EMBED_ALLOW_DOWNLOADS": "1",
 }
-with open(path, "w") as f: json.dump(cfg, f, indent=2)
+
+
+def load_json(path):
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as handle:
+            return json.load(handle)
+    except (ValueError, OSError) as exc:
+        # A corrupt agent config must not take the whole container down.
+        print("WARNING: could not parse %s (%s); leaving it alone" % (path, exc), file=sys.stderr)
+        return None
+
+
+def write_json_if_changed(path, cfg, before):
+    after = json.dumps(cfg, indent=2, sort_keys=True)
+    if after == before:
+        return
+    with open(path, "w") as handle:
+        json.dump(cfg, handle, indent=2)
+
+
+def upsert_json(path, container_key, entry):
+    cfg = load_json(path)
+    if cfg is None:
+        return
+    before = json.dumps(cfg, indent=2, sort_keys=True)
+    cfg.setdefault(container_key, {})["mempalace"] = entry
+    write_json_if_changed(path, cfg, before)
+
+
+upsert_json(gemini_path, "mcpServers", {"command": binary, "env": dict(env)})
+upsert_json(claude_path, "mcpServers", {"command": binary, "env": dict(env)})
+upsert_json(
+    opencode_path,
+    "mcp",
+    {"type": "local", "enabled": True, "command": [binary], "environment": dict(env)},
+)
+
+# Codex uses TOML and Python ships no stdlib writer, so the mempalace tables are
+# stripped and re-appended. The lookahead ends a section at the next table
+# header at line start (not at any "[") so that a value containing a TOML array
+# does not truncate the match and leave orphaned syntax behind.
+try:
+    with open(codex_path) as handle:
+        codex = handle.read()
+except OSError:
+    codex = ""
+
+stripped = re.sub(
+    r"(?ms)^\[mcp_servers\.mempalace(?:\.[A-Za-z0-9_]+)?\].*?(?=^\[|\Z)",
+    "",
+    codex,
+).rstrip()
+
+block = ['[mcp_servers.mempalace]', 'command = "%s"' % binary, '', '[mcp_servers.mempalace.env]']
+block += ['%s = "%s"' % (key, value) for key, value in env.items()]
+desired = (stripped + "\n\n" if stripped else "") + "\n".join(block) + "\n"
+
+if desired != codex:
+    with open(codex_path, "w") as handle:
+        handle.write(desired)
 PYEOF
-  fi
 fi
 
 # ── cache rotation ────────────────────────────────────────────

--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -65,6 +65,7 @@ resource "google_compute_instance" "actuarius" {
     env-enable-opencode-execution        = var.enable_opencode_execution
     env-enable-mempalace                 = var.enable_mempalace
     env-enable-mempalace-remote          = var.enable_mempalace_remote
+    env-mempalace-embedding-profile      = var.mempalace_embedding_profile
     env-mempalace-remote-url             = var.mempalace_remote_url
     env-mempalace-remote-bind            = var.mempalace_remote_bind
     env-mempalace-remote-name            = var.mempalace_remote_name

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -110,6 +110,17 @@ variable "enable_mempalace_remote" {
   description = "Enable Actuarius' loopback MemPalace federation server for repo memory."
 }
 
+variable "mempalace_embedding_profile" {
+  type        = string
+  default     = "low_cpu"
+  description = "MemPalace embedding profile: low_cpu (quantized model, bounded ingest batches) or balanced (fp32, unbounded). Keep low_cpu on the e2-micro."
+
+  validation {
+    condition     = contains(["low_cpu", "balanced"], var.mempalace_embedding_profile)
+    error_message = "mempalace_embedding_profile must be either \"low_cpu\" or \"balanced\"."
+  }
+}
+
 variable "mempalace_remote_url" {
   type        = string
   default     = ""

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -124,6 +124,7 @@ ENABLE_GEMINI=$(get_meta "env-enable-gemini-execution" || true)
 ENABLE_OPENCODE=$(get_meta "env-enable-opencode-execution" || true)
 ENABLE_MEMPALACE=$(get_meta "env-enable-mempalace" || true)
 ENABLE_MEMPALACE_REMOTE=$(get_meta "env-enable-mempalace-remote" || true)
+MEMPALACE_EMBEDDING_PROFILE=$(get_meta "env-mempalace-embedding-profile" || true)
 MEMPALACE_REMOTE_URL=$(get_meta "env-mempalace-remote-url" || true)
 MEMPALACE_REMOTE_BIND=$(get_meta "env-mempalace-remote-bind" || true)
 MEMPALACE_REMOTE_NAME=$(get_meta "env-mempalace-remote-name" || true)
@@ -176,6 +177,9 @@ if [ "$ENABLE_MEMPALACE_REMOTE" = "true" ]; then
   # docker-proxy. Host exposure is still governed by the 127.0.0.1 publish.
   MEMPALACE_REMOTE_BIND="0.0.0.0:$REMOTE_PORT"
   EXTRA_ARGS+=(-p "127.0.0.1:$REMOTE_PORT:$REMOTE_PORT")
+fi
+if [ -n "$MEMPALACE_EMBEDDING_PROFILE" ]; then
+  EXTRA_ARGS+=(-e "MEMPALACE_EMBEDDING_PROFILE=$MEMPALACE_EMBEDDING_PROFILE")
 fi
 if [ -n "$MEMPALACE_REMOTE_URL" ]; then
   EXTRA_ARGS+=(-e "MEMPALACE_REMOTE_URL=$MEMPALACE_REMOTE_URL")

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,6 +133,12 @@ const envSchema = z.object({
   MEMPALACE_PALACE_PATH: z.string().default("/data/mempalace/palace"),
   MEMPALACE_BINARY_PATH: z.string().default("/usr/local/bin/mempalace-mcp"),
   MEMPALACE_CLI_PATH: z.string().default("/usr/local/bin/mempalace-cli"),
+  // The bot runs on a 1GB e2-micro. MemPalace's own default is `balanced`, which
+  // uses the fp32 model and leaves every runtime guardrail unbounded
+  // (ingest batch size, queue depth, worker threads). `low_cpu` uses the
+  // quantized model and bounded batches, and is the only profile with a
+  // declared RSS budget.
+  MEMPALACE_EMBEDDING_PROFILE: z.enum(["balanced", "low_cpu"]).default("low_cpu"),
   MEMPALACE_REMOTE_ENABLED: z.string().default("false").transform((value) => value === "true"),
   MEMPALACE_REMOTE_PALACE_PATH: z.string().default("/data/mempalace/remote-palace"),
   MEMPALACE_REMOTE_BIND: z.string().default("127.0.0.1:8765"),
@@ -229,6 +235,7 @@ export const appConfig = {
   mempalacePalacePath: rawConfig.MEMPALACE_PALACE_PATH,
   mempalaceBinaryPath: rawConfig.MEMPALACE_BINARY_PATH,
   mempalaceCliPath: rawConfig.MEMPALACE_CLI_PATH,
+  mempalaceEmbeddingProfile: rawConfig.MEMPALACE_EMBEDDING_PROFILE,
   mempalaceRemoteEnabled: rawConfig.MEMPALACE_REMOTE_ENABLED,
   mempalaceRemotePalacePath: rawConfig.MEMPALACE_REMOTE_PALACE_PATH,
   mempalaceRemoteBind: rawConfig.MEMPALACE_REMOTE_BIND,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,12 @@ async function main(): Promise<void> {
   let memPalace: MemPalaceClient | null = null;
   if (appConfig.mempalaceEnabled) {
     await ensurePalaceIdentity(logger);
-    memPalace = new MemPalaceClient(appConfig.mempalaceBinaryPath, appConfig.mempalacePalacePath, logger);
+    memPalace = new MemPalaceClient(
+      appConfig.mempalaceBinaryPath,
+      appConfig.mempalacePalacePath,
+      logger,
+      appConfig.mempalaceEmbeddingProfile
+    );
     try {
       await memPalace.start();
     } catch (err) {

--- a/src/services/memPalaceClient.ts
+++ b/src/services/memPalaceClient.ts
@@ -105,7 +105,8 @@ export class MemPalaceClient {
   public constructor(
     private readonly binaryPath: string,
     private readonly palacePath: string,
-    private readonly logger: Logger
+    private readonly logger: Logger,
+    private readonly embeddingProfile: string = "low_cpu"
   ) {}
 
   public async start(): Promise<void> {
@@ -117,6 +118,7 @@ export class MemPalaceClient {
       env: {
         ...process.env,
         MEMPALACE_PALACE_PATH: this.palacePath,
+        MEMPALACE_EMBEDDING_PROFILE: this.embeddingProfile,
         MEMPALACE_EMBED_ALLOW_DOWNLOADS: "1",
       },
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/services/memPalaceRemoteService.ts
+++ b/src/services/memPalaceRemoteService.ts
@@ -500,6 +500,7 @@ export class MemPalaceRemoteService {
     return {
       ...process.env,
       MEMPALACE_REMOTE_TOKEN: this.remoteToken ?? process.env.MEMPALACE_REMOTE_TOKEN ?? "",
+      MEMPALACE_EMBEDDING_PROFILE: this.config.mempalaceEmbeddingProfile,
       MEMPALACE_EMBED_ALLOW_DOWNLOADS: "1"
     };
   }

--- a/tests/redeployScript.test.ts
+++ b/tests/redeployScript.test.ts
@@ -330,4 +330,21 @@ describe("scripts/redeploy.sh auth validation", () => {
     expect(result.dockerLog).toContain("GEMINI_API_KEY=gemini-key");
     expect(result.dockerLog).toContain("MEMPALACE_REMOTE_TOKEN=fed-token");
   });
+
+  it("forwards the MemPalace embedding profile from instance metadata", () => {
+    const result = runRedeploy(
+      { ...baseMetadata, "env-mempalace-embedding-profile": "low_cpu" },
+      { ...baseSecrets, "actuarius-gh-token": "gh-token" }
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.dockerLog).toContain("MEMPALACE_EMBEDDING_PROFILE=low_cpu");
+  });
+
+  it("omits the embedding profile flag when the metadata key is absent", () => {
+    const result = runRedeploy(baseMetadata, { ...baseSecrets, "actuarius-gh-token": "gh-token" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.dockerLog).not.toContain("MEMPALACE_EMBEDDING_PROFILE=");
+  });
 });


### PR DESCRIPTION
## Why

MemPalace defaults to the `balanced` embedding profile. That is the wrong default for this deployment, and it is not just about model size — `balanced` disables every runtime guardrail:

| | `balanced` (current) | `low_cpu` (this PR) |
|---|---|---|
| model | fp32 (~86 MB) | quantized |
| `ingest_batch_size` | unbounded | 8 (4 in degraded mode) |
| `queue_limit` | unbounded | 32 |
| `worker_threads` | unlimited | 1 |
| declared RSS budget | none | 450 MB idle / 850 MB ingest |

The bot runs on a 1 GB e2-micro with a 700 MiB container cap. `dmesg` on the live VM shows the cgroup OOM-killer has already killed `opencode` twice, the host is holding ~709 MB of swap, and unbounded ingest batches are implicated in the repeated `MemPalace remote mine failed` entries in the container log.

Notably, even `low_cpu`'s own 450 MB idle budget times the two MemPalace processes the bot runs exceeds the 700 MiB cap — so this reduces pressure but does not by itself resolve the sizing question.

## What

Defaults the profile to `low_cpu` and makes it configurable end to end rather than hardcoding it:

Terraform variable (validated to `low_cpu`/`balanced`) → instance metadata → `redeploy.sh` → container env, with a `Dockerfile` `ENV` as the baseline so plain `docker run` gets it too. App side is a zod-validated enum in `config.ts`, and both spawn sites (`memPalaceClient` for the bot's own MCP process, `buildProcessEnv` for the `serve`/mine subprocesses) forward it explicitly instead of relying on ambient inheritance.

**The easy thing to miss:** `entrypoint.sh` registers MemPalace into four separate agent MCP configs (Gemini, Claude, Codex, OpenCode), each with its own explicit `env` block. Agent-spawned MCP servers do not reliably inherit container environment, so setting only the container env would have left the agents' own MemPalace instances on `balanced` — which is most of the actual memory pressure. All four now carry the profile.

## Verification

- `npm run check` clean.
- Full suite: 654 passed / 2 failed. The two failures are in `tests/spawnCollect.test.ts` and are **pre-existing** — confirmed by stashing this branch's changes and re-running the full suite on a clean tree, where the identical two fail. They are load-sensitive timeout assertions that pass when that file runs alone.
- Two new `redeploy.sh` tests cover both the metadata-forwarding path and the absent-metadata path.

## Deploy notes

Requires an image rebuild (`Dockerfile` and `entrypoint.sh` changed). The quantized model is not in the VM's cache and will download on first use — `MEMPALACE_EMBED_ALLOW_DOWNLOADS` is already forced on in `buildProcessEnv`, so no manual step.

## Follow-up (not in this PR)

`docker/entrypoint.sh` does `rm -rf "$HOME/.cache"` on every container start, and `XDG_CACHE_HOME` is where MemPalace keeps its downloaded model — so the model is re-fetched on every restart. Confirmed on the live VM: container started 04:39 UTC, every model file stamped 04:49. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
