### PR TITLE
test: deflake load-sensitive spawnCollect timeout tests

### DIFF
--- a/tests/spawnCollect.test.ts
+++ b/tests/spawnCollect.test.ts
@@ -127,6 +127,11 @@ describe("spawnCollect — stderr trimming", () => {
   // Each duration below therefore has a stated safety factor; keep them if you
   // retune. Total wall-clock cost is ~2s per test, which is the price of not
   // being flaky.
+  //
+  // Both also pass an explicit per-test timeout that sits ABOVE the spawnCollect
+  // budget they exercise. vitest's default is 5000ms, which these would approach
+  // under load — and a generic "Test timed out in 5000ms" would preempt the
+  // ETIMEDOUT assertion, reintroducing the exact flake this file is fixing.
   const WRITE_INTERVAL_MS = 50;
 
   it("resets the inactivity timeout when either output stream produces data", async () => {
@@ -149,7 +154,7 @@ describe("spawnCollect — stderr trimming", () => {
     // Writes alternate stdout/stderr starting with stdout, so each gets half.
     expect(result.stdout).toBe("x".repeat(writes / 2));
     expect(result.stderr).toBe("x".repeat(writes / 2));
-  });
+  }, 35_000); // above the 30s spawnCollect absolute budget above
 
   it("still enforces the absolute timeout while a process keeps producing output", async () => {
     // The child never stops writing, so only a timeout can end it. The idle
@@ -163,7 +168,7 @@ describe("spawnCollect — stderr trimming", () => {
     ).catch((reason: unknown) => reason);
 
     expect(error).toMatchObject({ code: "ETIMEDOUT", timeoutReason: "absolute" });
-  });
+  }, 15_000); // above the 2s spawnCollect absolute budget above
 
   it.each(["stdout", "stderr"] as const)(
     "rejects and terminates the child when an onOutput callback throws from %s",

--- a/tests/spawnCollect.test.ts
+++ b/tests/spawnCollect.test.ts
@@ -119,22 +119,47 @@ describe("spawnCollect — stderr trimming", () => {
     expect(error).toMatchObject({ code: "ETIMEDOUT", timeoutReason: "idle" });
   });
 
+  // The two timing tests below race a real child process against real timers,
+  // so their durations are chosen as ratios rather than tight absolute values.
+  // spawnCollect arms both timers at spawn() time, but the child's first byte
+  // only arrives after Node's cold start — under a parallel `npm test` run that
+  // startup, and any single interval tick, can be stretched by scheduler load.
+  // Each duration below therefore has a stated safety factor; keep them if you
+  // retune. Total wall-clock cost is ~2s per test, which is the price of not
+  // being flaky.
+  const WRITE_INTERVAL_MS = 50;
+
   it("resets the inactivity timeout when either output stream produces data", async () => {
+    // The child writes 40 times at 50ms => ~2000ms of activity, well past the
+    // 900ms idle budget: if the idle timer did NOT reset on output it would fire
+    // at 900ms and this would reject instead of resolving. 900ms also gives 18x
+    // headroom over the write cadence and ~900ms of slack for Node's startup.
+    const writes = 40;
+    const idleTimeoutMs = 900;
+
     const result = await spawnCollect(
       node,
-      ["-e", "let count = 0; const timer = setInterval(() => { (count++ % 2 ? process.stderr : process.stdout).write('x'); if (count === 6) { clearInterval(timer); } }, 50);"],
-      { cwd, timeoutMs: 1_000, idleTimeoutMs: 120, maxBuffer: 1024 },
+      [
+        "-e",
+        `let count = 0; const timer = setInterval(() => { (count++ % 2 ? process.stderr : process.stdout).write('x'); if (count === ${writes}) { clearInterval(timer); } }, ${WRITE_INTERVAL_MS});`,
+      ],
+      { cwd, timeoutMs: 30_000, idleTimeoutMs, maxBuffer: 1024 },
     );
 
-    expect(result.stdout).toBe("xxx");
-    expect(result.stderr).toBe("xxx");
+    // Writes alternate stdout/stderr starting with stdout, so each gets half.
+    expect(result.stdout).toBe("x".repeat(writes / 2));
+    expect(result.stderr).toBe("x".repeat(writes / 2));
   });
 
   it("still enforces the absolute timeout while a process keeps producing output", async () => {
+    // The child never stops writing, so only a timeout can end it. The idle
+    // budget (1000ms, 20x the write cadence) must lose the race to the absolute
+    // budget (2000ms) — that is what `timeoutReason: "absolute"` proves. It also
+    // leaves ~1000ms for Node's startup before the first write lands.
     const error = await spawnCollect(
       node,
-      ["-e", "setInterval(() => process.stdout.write('x'), 20);"],
-      { cwd, timeoutMs: 180, idleTimeoutMs: 100, maxBuffer: 1024 },
+      ["-e", `setInterval(() => process.stdout.write('x'), ${WRITE_INTERVAL_MS});`],
+      { cwd, timeoutMs: 2_000, idleTimeoutMs: 1_000, maxBuffer: 1024 * 1024 },
     ).catch((reason: unknown) => reason);
 
     expect(error).toMatchObject({ code: "ETIMEDOUT", timeoutReason: "absolute" });


### PR DESCRIPTION
## What

Retunes the timing of two tests in `tests/spawnCollect.test.ts` that were flaky under a full `npm test` run. **No production code changed.**

- `resets the inactivity timeout when either output stream produces data`
- `still enforces the absolute timeout while a process keeps producing output`

## Why

Both tests passed when the file ran alone (`npx vitest run tests/spawnCollect.test.ts`) but failed during `npm test`, where 33 test files compete for cores. Confirmed pre-existing and unrelated to any working-tree change — they fail identically on a clean checkout (verified with `git stash`). Reproduced on win32.

The root cause is **startup latency, not write cadence**. `spawnCollect` arms both its absolute and idle timers synchronously at `spawn()` time (`src/utils/spawnCollect.ts:536-552`), before the child has produced a single byte, so Node''s cold start is charged against the idle budget. A 120 ms idle timeout was effectively asserting "Node boots in under 120 ms" — true when the machine is idle, false under contention.

Each test also broke by a distinct mechanism:

| Test | Old config | Failure mode |
|---|---|---|
| resets the inactivity timeout | idle 120 ms, writes every 50 ms | idle was only **2.4x** the cadence; one stretched interval killed the child, so the promise rejected and the `result.stdout` assertion never ran |
| enforces the absolute timeout | absolute 180 ms, idle 100 ms, writes every 20 ms | idle was only **5x** the cadence; a stall fired *idle* first, so `timeoutReason` came back `"idle"` instead of `"absolute"` |

## How

Rebalanced the three durations in each test as **ratios** rather than tight absolute values, keeping what each test actually proves:

- **resets the inactivity timeout** — 40 writes @ 50 ms against a 900 ms idle budget (18x cadence, ~900 ms of startup slack), absolute 30 s. The proof is unchanged and still load-bearing: the child stays busy for ~2000 ms, longer than the 900 ms budget, so a non-resetting timer would still kill it and fail the test.
- **enforces the absolute timeout** — absolute 2000 ms vs idle 1000 ms with a 50 ms cadence (20x). The asserted race (absolute must beat idle) is preserved. `maxBuffer` also raised to 1 MB so a fast-writing child cannot trip `EMSGSIZE` and reject with the wrong `code` before the timeout lands.

The safety factors are documented in an inline comment block so a future retune does not silently reintroduce the flake.

### Why not fake timers

`vi.useFakeTimers()` was considered and deliberately rejected. These tests exercise a **real** child process and real stream events; faking timers would freeze the `setTimeout`s inside `spawnCollect` while the OS keeps running the child in wall-clock time, decoupling the two clocks and making the race *less* meaningful, not more.

## Reviewer notes

- Cost is ~2 s per test (~4 s total added wall clock). The full suite still runs in ~21 s.
- Notably, the reset test takes **2494 ms** for ~2000 ms of scheduled writes even with **zero** contention — a ~25% cadence drift on an idle machine, which is what motivated the generous margins.

## Verification

- `npx vitest run tests/spawnCollect.test.ts` — 31 passed
- `npm test` — **33 files, 654 passed, 10 skipped**. Timings under concurrent load are essentially identical to the isolated run (2531 ms vs 2494 ms), confirming the margins absorb the contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)