### PR TITLE
[codex] Bump Jules PR reviewer to v2.2.1

### DIFF
--- a/.github/workflows/jules-review.yml
+++ b/.github/workflows/jules-review.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - uses: DigitumDei/jules-pr-reviewer@v2.2.0
+      - uses: DigitumDei/jules-pr-reviewer@v2.2.1
         with:
           jules_api_key: ${{ secrets.JULES_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed

- Update the Jules PR reviewer action from `v2.2.0` to `v2.2.1`.

## Why

Version `2.2.1` prefixes Jules session titles with the PR number and repository name, making concurrent reviews distinguishable in the Jules web UI.

## Validation

- The workflow-only change points to the immutable `v2.2.1` release tag.
- The release commit passed the reviewer repository's typecheck, build, diff check, and dogfood workflow.
