### PR TITLE
Route all non-diary container writes to the remote palace

### DIFF
--- a/src/services/memPalaceRemoteService.ts
+++ b/src/services/memPalaceRemoteService.ts
@@ -485,7 +485,16 @@ export class MemPalaceRemoteService {
       federation: {
         ...federation,
         remotes,
-        default_mode: typeof federation.default_mode === "string" ? federation.default_mode : "local",
+        // Route every non-diary write to the shared (remote) palace: the container
+        // is ephemeral, so its knowledge must live on the canonical serve palace,
+        // not the agent's local store. Set unconditionally — deliberately unlike
+        // the preserve-operator pattern used for wings/kg above — because this is a
+        // hard policy ("all non-diary writes go remote"), and $HOME/.mempalace lives
+        // on the persistent /data disk, so a stale persisted "local" (or an operator
+        // "combined") would otherwise survive redeploys and silently defeat it.
+        // Diaries are always-local by the tool contract; repo wings and kg already
+        // write: remote, so only untracked wings change behavior here.
+        default_mode: "remote",
         wings,
         kg
       }

--- a/tests/memPalaceRemoteService.test.ts
+++ b/tests/memPalaceRemoteService.test.ts
@@ -151,11 +151,35 @@ describe("MemPalaceRemoteService", () => {
     );
     expect(globalConfig.federation.wings[wing]).toEqual({ mode: "combined", remote: "actuarius", write: "remote" });
     expect(globalConfig.federation.kg).toEqual({ mode: "combined", remote: "actuarius", write: "remote" });
+    expect(globalConfig.federation.default_mode).toBe("remote");
     expect(globalConfig.federation.remotes[0]).not.toHaveProperty("token_env");
 
     const tokenEntries = JSON.parse(readFileSync(config.mempalaceRemoteTokenFile, "utf8"));
     expect(tokenEntries[0]).toMatchObject({ name: "actuarius-local", token: "test-token", enabled: true });
     expect(readFileSync(join(checkoutPath, ".git", "info", "exclude"), "utf8")).toContain("mempalace.yaml");
+  });
+
+  it("forces default_mode to remote, overriding a persisted local so all non-diary writes route to the shared palace", async () => {
+    const root = mkdtempSync(join(tmpdir(), "actuarius-mempalace-defaultmode-"));
+    const homeDir = join(root, "home");
+    const config = makeConfig(root);
+    const repo = makeRepo();
+    const checkoutPath = join(config.reposRootPath, repo.owner, repo.repo);
+    mkdirSync(join(checkoutPath, ".git", "info"), { recursive: true });
+    mkdirSync(join(homeDir, ".mempalace"), { recursive: true });
+    // The bot's old default "local" gets baked onto the persistent /data disk; it
+    // must not survive — the container routes every non-diary write remote.
+    writeFileSync(
+      join(homeDir, ".mempalace", "config.json"),
+      JSON.stringify({ federation: { default_mode: "local" } }),
+      "utf8"
+    );
+
+    const service = new MemPalaceRemoteService(config, logger, { homeDir });
+    await service.registerRepository(repo, checkoutPath);
+
+    const globalConfig = JSON.parse(readFileSync(join(homeDir, ".mempalace", "config.json"), "utf8"));
+    expect(globalConfig.federation.default_mode).toBe("remote");
   });
 
   it("prunes stale bot-managed wing rules and checkouts, preserving operator-authored rules", async () => {


### PR DESCRIPTION
## What
On the Actuarius container, route **all non-diary** MemPalace writes to the remote (shared) palace by setting `federation.default_mode` to `"remote"` unconditionally in `writeGlobalConfigOnce`.

## Why
- The container is ephemeral; its knowledge should live on the canonical serve palace, not the agent's per-instance local store.
- Repo wings and KG already write `remote`; diaries are always-local by the tool contract. The remaining gap was **untracked wings**, which fell through to `default_mode` — previously `"local"`.
- `$HOME/.mempalace` is on the persistent `/data` disk (`Dockerfile`: `HOME=/data/home/appuser`, `VOLUME ["/data"]`), so a previously-persisted `"local"` would survive redeploys. The change is therefore **unconditional** (not preserved) — a deliberate departure from the preserve-operator pattern used for wings/KG — because "all non-diary → remote" is a hard guarantee that a preserved (or operator `"combined"`) value could silently break.

## Tests
- Existing config-generation test now asserts `default_mode === "remote"`.
- New test: a persisted `{ federation: { default_mode: "local" } }` is overridden to `"remote"`.
- `npm run check` clean; full suite green (673 passed / 11 skipped).

## Deploy
Takes effect on redeploy — the container regenerates `~/.mempalace/config.json` on boot. The home-side counterpart (the 8 repo wings + KG → `write: both`) was applied directly to the home palace config as a separate, non-repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
