### PR TITLE
Fix dynamic MemPalace project wing context

### DIFF
--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -101,6 +101,7 @@ import {
   buildOpencodePlanWorkflowPrompt,
   buildPlanImplementationPrompt,
   buildPlanPrompt,
+  buildRepositoryMemoryScopedPrompt,
   buildRepositoryScopedPrompt,
   buildRevisionPlanPrompt,
   buildThreadFollowUpPrompt
@@ -970,13 +971,14 @@ export class ActuariusBot {
   private async prepareWorktreeMemoryConfig(
     repo: RepoRow | { owner: string; repo: string; fullName: string },
     worktreePath: string
-  ): Promise<void> {
-    if (!this.memPalaceRemote) return;
+  ): Promise<string | null> {
+    if (!this.memPalaceRemote) return null;
     const identity = this.toRepoMemoryIdentity(repo);
     try {
-      await this.memPalaceRemote.ensureWorktreeConfig(identity, worktreePath);
+      return await this.memPalaceRemote.ensureWorktreeConfig(identity, worktreePath);
     } catch (error) {
       this.logger.warn({ error, repo: identity.fullName, worktreePath }, "MemPalace worktree config preparation failed");
+      return null;
     }
   }
 
@@ -3095,6 +3097,7 @@ export class ActuariusBot {
     guildId: string;
     repoId: number;
     threadId?: string | null;
+    memoryWing?: string | null | undefined;
   }): {
     analyzer: ReviewModelRunner;
     reviewers: ReviewModelRunner[];
@@ -3123,7 +3126,15 @@ export class ActuariusBot {
       ...(defaultModel ? { model: defaultModel } : {}),
       label: slotIndex !== undefined ? `${AI_PROVIDER_LABELS[provider]} (Slot ${slotIndex})` : AI_PROVIDER_LABELS[provider],
       run: async ({ prompt, cwd, timeoutMs, model }) =>
-        this.runProviderText({ provider, prompt, cwd, timeoutMs, ...(model ? { model } : {}), env: reviewEnv })
+        this.runProviderText({
+          provider,
+          prompt,
+          cwd,
+          timeoutMs,
+          ...(model ? { model } : {}),
+          env: reviewEnv,
+          memoryWing: input.memoryWing
+        })
     });
 
     if (slots.length > 0) {
@@ -3229,9 +3240,13 @@ export class ActuariusBot {
     model?: string;
     env?: NodeJS.ProcessEnv;
     role?: "implementation" | "planner" | "verification";
+    memoryWing?: string | null | undefined;
   }): Promise<string> {
     const request = {
-      prompt: input.prompt,
+      prompt: buildRepositoryMemoryScopedPrompt({
+        prompt: input.prompt,
+        memoryWing: input.memoryWing
+      }),
       cwd: input.cwd,
       timeoutMs: input.timeoutMs ?? this.config.askExecutionTimeoutMs,
       idleTimeoutMs: this.config.providerIdleTimeoutMs,
@@ -3407,10 +3422,15 @@ export class ActuariusBot {
               await reviewThread.send("Uncommitted changes in the worktree were auto-committed for review.");
             }
 
+            const memoryWing = await this.prepareWorktreeMemoryConfig(
+              { owner: repo.owner, repo: repo.repo, fullName: repo.full_name },
+              latestRequest.worktree_path!
+            );
             const runners = this.buildReviewRunners({
               guildId: interaction.guildId!,
               repoId: repo.id,
-              threadId: interaction.channelId
+              threadId: interaction.channelId,
+              memoryWing
             });
             const threadHistory = await this.buildThreadHistory(reviewThread);
             resolve(await runAdversarialReview({
@@ -3951,6 +3971,7 @@ export class ActuariusBot {
     env: NodeJS.ProcessEnv | undefined;
     timeoutMs: number;
     verificationTimeoutMs: number;
+    memoryWing?: string | null | undefined;
   }): Promise<{
     tasks: IterativePlanTask[];
     overview: string;
@@ -3993,7 +4014,7 @@ export class ActuariusBot {
       plannerModel: input.planner.model,
       implementerProvider: input.implementer.provider,
       implementerModel: input.implementer.model,
-      runProviderText: async (opts) => this.runProviderText(opts),
+      runProviderText: async (opts) => this.runProviderText({ ...opts, memoryWing: input.memoryWing }),
       timeoutMs: input.timeoutMs,
       verificationTimeoutMs: input.verificationTimeoutMs,
       env: input.env,
@@ -4093,7 +4114,7 @@ export class ActuariusBot {
       }, input.requestId);
       worktreePath = worktree.path;
       branchName = worktree.branchName;
-      await this.prepareWorktreeMemoryConfig(input.repo, worktreePath);
+      const memoryWing = await this.prepareWorktreeMemoryConfig(input.repo, worktreePath);
       this.db.updateRequestWorkspace(input.requestId, worktreePath, branchName);
 
       const executionEnvironment = this.installService.buildMinimalExecutionEnvironment({
@@ -4121,7 +4142,8 @@ export class ActuariusBot {
         timeoutMs: this.config.askExecutionTimeoutMs,
         role: "planner",
         ...(input.planner.model ? { model: input.planner.model } : {}),
-        env
+        env,
+        memoryWing
       });
       if (!planText.trim()) {
         markFailed();
@@ -4147,7 +4169,8 @@ export class ActuariusBot {
           implementer: input.implementer,
           env,
           timeoutMs: this.config.askExecutionTimeoutMs,
-          verificationTimeoutMs: this.config.iterativeVerificationTimeoutMs
+          verificationTimeoutMs: this.config.iterativeVerificationTimeoutMs,
+          memoryWing
         });
 
         this.db.updateRequestStatus(input.requestId, "succeeded");
@@ -4204,7 +4227,8 @@ export class ActuariusBot {
           timeoutMs: this.config.askExecutionTimeoutMs,
           role: "implementation",
           ...(input.implementer.model ? { model: input.implementer.model } : {}),
-          env
+          env,
+          memoryWing
         });
         for (const chunk of splitIntoDiscordMessages(implementationText, implementerLabel)) {
           await threadChannel.send(chunk);
@@ -4334,7 +4358,7 @@ export class ActuariusBot {
       }, input.requestId);
       worktreePath = worktree.path;
       branchName = worktree.branchName;
-      await this.prepareWorktreeMemoryConfig(input.repo, worktreePath);
+      const memoryWing = await this.prepareWorktreeMemoryConfig(input.repo, worktreePath);
       this.db.updateRequestWorkspace(input.requestId, worktreePath, branchName);
 
       const executionEnvironment = this.installService.buildMinimalExecutionEnvironment({
@@ -4356,10 +4380,13 @@ export class ActuariusBot {
       );
 
       const result = await runOpencodeAgentRequest({
-        prompt: buildOpencodePlanWorkflowPrompt({
-          repoFullName: input.repo.fullName,
-          requestPrompt: input.prompt,
-          implementerAgent: OPENCODE_IMPLEMENT_OC_AGENT
+        prompt: buildRepositoryMemoryScopedPrompt({
+          prompt: buildOpencodePlanWorkflowPrompt({
+            repoFullName: input.repo.fullName,
+            requestPrompt: input.prompt,
+            implementerAgent: OPENCODE_IMPLEMENT_OC_AGENT
+          }),
+          memoryWing
         }),
         cwd: worktreePath,
         timeoutMs: this.config.askExecutionTimeoutMs,
@@ -4512,7 +4539,7 @@ export class ActuariusBot {
         this.logger.error({ requestId: input.requestId, worktreePath: input.worktreePath }, "Revise request worktree no longer exists");
         return;
       }
-      await this.prepareWorktreeMemoryConfig(input.repo, input.worktreePath);
+      const memoryWing = await this.prepareWorktreeMemoryConfig(input.repo, input.worktreePath);
       const reviewDiff = await getReviewDiff(input.worktreePath, { headRef: input.branchName, excludePaths: ["docs/reviews/**"] });
       const currentDiff = reviewDiff.diffText;
 
@@ -4541,7 +4568,8 @@ export class ActuariusBot {
         timeoutMs: this.config.askExecutionTimeoutMs,
         role: "planner",
         ...(input.planner.model ? { model: input.planner.model } : {}),
-        env
+        env,
+        memoryWing
       });
 
       if (!planText.trim()) {
@@ -4566,7 +4594,8 @@ export class ActuariusBot {
         implementer: input.implementer,
         env,
         timeoutMs: this.config.askExecutionTimeoutMs,
-        verificationTimeoutMs: this.config.iterativeVerificationTimeoutMs
+        verificationTimeoutMs: this.config.iterativeVerificationTimeoutMs,
+        memoryWing
       });
 
       this.db.updateRequestStatus(input.requestId, "succeeded");
@@ -4666,6 +4695,7 @@ export class ActuariusBot {
     let statusFinalized = false;
     let stage = "init";
     let threadChannel: Awaited<ReturnType<Client["channels"]["fetch"]>> | null = null;
+    let memoryWing: string | null = null;
 
     const markFailed = (): void => {
       if (statusFinalized) {
@@ -4695,7 +4725,7 @@ export class ActuariusBot {
 
       if (input.existingWorktreePath) {
         worktreePath = input.existingWorktreePath;
-        await this.prepareWorktreeMemoryConfig(input.repo, worktreePath);
+        memoryWing = await this.prepareWorktreeMemoryConfig(input.repo, worktreePath);
         this.logger.info({ requestId: input.requestId, worktreePath, branchName }, "Reusing existing worktree for follow-up");
       } else {
         stage = "sync-repo";
@@ -4722,7 +4752,7 @@ export class ActuariusBot {
         );
         worktreePath = worktree.path;
         branchName = worktree.branchName;
-        await this.prepareWorktreeMemoryConfig(input.repo, worktreePath);
+        memoryWing = await this.prepareWorktreeMemoryConfig(input.repo, worktreePath);
         this.logger.info(
           { requestId: input.requestId, branchName: worktree.branchName, worktreePath: worktree.path },
           "Request worktree created"
@@ -4781,6 +4811,7 @@ export class ActuariusBot {
         prompt: effectivePrompt,
         cwd: worktreePath,
         env: executionEnvironment.env,
+        memoryWing,
         ...(input.model ? { model: input.model } : {})
       });
 

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -3097,7 +3097,6 @@ export class ActuariusBot {
     guildId: string;
     repoId: number;
     threadId?: string | null;
-    memoryWing?: string | null | undefined;
   }): {
     analyzer: ReviewModelRunner;
     reviewers: ReviewModelRunner[];
@@ -3132,8 +3131,7 @@ export class ActuariusBot {
           cwd,
           timeoutMs,
           ...(model ? { model } : {}),
-          env: reviewEnv,
-          memoryWing: input.memoryWing
+          env: reviewEnv
         })
     });
 
@@ -3422,15 +3420,10 @@ export class ActuariusBot {
               await reviewThread.send("Uncommitted changes in the worktree were auto-committed for review.");
             }
 
-            const memoryWing = await this.prepareWorktreeMemoryConfig(
-              { owner: repo.owner, repo: repo.repo, fullName: repo.full_name },
-              latestRequest.worktree_path!
-            );
             const runners = this.buildReviewRunners({
               guildId: interaction.guildId!,
               repoId: repo.id,
-              threadId: interaction.channelId,
-              memoryWing
+              threadId: interaction.channelId
             });
             const threadHistory = await this.buildThreadHistory(reviewThread);
             resolve(await runAdversarialReview({
@@ -4014,7 +4007,12 @@ export class ActuariusBot {
       plannerModel: input.planner.model,
       implementerProvider: input.implementer.provider,
       implementerModel: input.implementer.model,
-      runProviderText: async (opts) => this.runProviderText({ ...opts, memoryWing: input.memoryWing }),
+      runProviderText: async (opts) => this.runProviderText({
+        ...opts,
+        ...(opts.role === "implementation" && input.memoryWing
+          ? { memoryWing: input.memoryWing }
+          : {})
+      }),
       timeoutMs: input.timeoutMs,
       verificationTimeoutMs: input.verificationTimeoutMs,
       env: input.env,
@@ -4142,8 +4140,7 @@ export class ActuariusBot {
         timeoutMs: this.config.askExecutionTimeoutMs,
         role: "planner",
         ...(input.planner.model ? { model: input.planner.model } : {}),
-        env,
-        memoryWing
+        env
       });
       if (!planText.trim()) {
         markFailed();
@@ -4568,8 +4565,7 @@ export class ActuariusBot {
         timeoutMs: this.config.askExecutionTimeoutMs,
         role: "planner",
         ...(input.planner.model ? { model: input.planner.model } : {}),
-        env,
-        memoryWing
+        env
       });
 
       if (!planText.trim()) {

--- a/src/services/llmPromptBuilders.ts
+++ b/src/services/llmPromptBuilders.ts
@@ -42,6 +42,24 @@ export function clipPromptText(text: string, maxLength: number): string {
   return text.length <= maxLength ? text : `${text.slice(0, maxLength - 16).trimEnd()}\n...(truncated)`;
 }
 
+export function buildRepositoryMemoryScopedPrompt(input: {
+  prompt: string;
+  memoryWing?: string | null | undefined;
+}): string {
+  if (!input.memoryWing) return input.prompt;
+
+  return [
+    input.prompt,
+    "",
+    "## MemPalace repository memory",
+    "",
+    `The project memory wing for the repository being worked on is \`${input.memoryWing}\`.`,
+    "Use this exact wing for every repo-scoped MemPalace operation. Do not derive or invent a wing from the repository owner/name.",
+    "Store durable repository knowledge with `mempalace_add_drawer` in this wing. Project diary entries are local-only and do not replace durable drawers.",
+    "If you write a project-scoped diary entry, use this same wing. Consult `mempalace.yaml` for the repository's room definitions."
+  ].join("\n");
+}
+
 function matchesNewUserMessage(entryText: string, newMessageContent: string): boolean {
   const normalized = newMessageContent.trim();
   return entryText === normalized || entryText.startsWith(`${normalized}\n\n**Attachments**\n`);

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -1717,7 +1717,7 @@ describe("ActuariusBot review runner selection", () => {
     expect(runners.summarizer.model).toBe("gemini-2.5-pro");
   });
 
-  it("propagates the resolved repository wing to review provider runs", async () => {
+  it("does not inject repository memory into text-only review provider runs", async () => {
     const bot = createBot({
       getReviewerSlots: vi.fn().mockReturnValue([
         { slot_index: 1, provider: "claude", model: null },
@@ -1728,8 +1728,7 @@ describe("ActuariusBot review runner selection", () => {
 
     const runners = (bot as any).buildReviewRunners({
       guildId: "guild-1",
-      repoId: 1,
-      memoryWing: "wing_shotquill"
+      repoId: 1
     });
     await runners.reviewers[0].run({
       prompt: "Review the change.",
@@ -1737,10 +1736,9 @@ describe("ActuariusBot review runner selection", () => {
       timeoutMs: 1_000
     });
 
-    expect((bot as any).runProviderText).toHaveBeenCalledWith(expect.objectContaining({
-      prompt: "Review the change.",
-      memoryWing: "wing_shotquill"
-    }));
+    const call = vi.mocked((bot as any).runProviderText).mock.calls[0]![0];
+    expect(call.prompt).toBe("Review the change.");
+    expect(call).not.toHaveProperty("memoryWing");
   });
 });
 
@@ -4100,7 +4098,7 @@ describe("ActuariusBot plan runner", () => {
     expect(planPrompt).toContain("Produce a structured implementation plan");
     expect(planPrompt).not.toContain("iterative");
     expect(planPrompt).not.toContain("Return ONLY valid JSON");
-    expect(runCalls[0]![0].memoryWing).toBe("wing_hello_world");
+    expect(runCalls[0]![0]).not.toHaveProperty("memoryWing");
 
     const implPrompt = runCalls[1]![0].prompt;
     expect(implPrompt).toContain("Implement the request using the approved plan below");
@@ -4120,6 +4118,7 @@ describe("ActuariusBot plan runner", () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const updateRequestStatus = vi.fn();
     const bot = createBot({ updateRequestStatus });
+    (bot as any).prepareWorktreeMemoryConfig = vi.fn().mockResolvedValue("wing_hello_world");
     (bot as any).client.channels.fetch = vi.fn().mockResolvedValue({
       isThread: () => true,
       send
@@ -4166,6 +4165,23 @@ describe("ActuariusBot plan runner", () => {
         worktreePath: "/tmp/worktree-plan"
       })
     );
+    expect(runCalls[0]![0]).not.toHaveProperty("memoryWing");
+
+    const runTaskProvider = vi.mocked(runIterativeTaskLoop).mock.calls[0]![0].runProviderText;
+    await runTaskProvider({
+      provider: "claude",
+      prompt: "Implement task",
+      cwd: "/tmp/worktree-plan",
+      role: "implementation"
+    });
+    await runTaskProvider({
+      provider: "claude",
+      prompt: "Verify task",
+      cwd: "/tmp/worktree-plan",
+      role: "verification"
+    });
+    expect(runCalls[1]![0].memoryWing).toBe("wing_hello_world");
+    expect(runCalls[2]![0]).not.toHaveProperty("memoryWing");
     expect(updateRequestStatus).toHaveBeenCalledWith(93, "succeeded");
     expect(send).toHaveBeenCalledWith(expect.stringContaining("2 tasks"));
   });
@@ -5526,7 +5542,7 @@ describe("ActuariusBot revise command", () => {
       expect(runCalls.length).toBeGreaterThanOrEqual(1);
       for (const call of runCalls) {
         expect(call[0]).toHaveProperty("env");
-        expect(call[0].memoryWing).toBe("wing_hello_world");
+        expect(call[0]).not.toHaveProperty("memoryWing");
         const env = call[0].env;
         expect(env.OPENAI_API_KEY).toBe("sk-openai-test");
         expect(env.GEMINI_API_KEY).toBe("gemini-test");

--- a/tests/botCommands.test.ts
+++ b/tests/botCommands.test.ts
@@ -154,7 +154,11 @@ const { ActuariusBot } = await import("../src/discord/bot.js");
 
 const logger = pino({ level: "silent" });
 
-function createBot(dbOverrides: Record<string, unknown> = {}, memPalace: unknown = null): ActuariusBot {
+function createBot(
+  dbOverrides: Record<string, unknown> = {},
+  memPalace: unknown = null,
+  memPalaceRemote: unknown = null
+): ActuariusBot {
   const config = {
     discordToken: "token",
     discordClientId: "client",
@@ -210,7 +214,7 @@ function createBot(dbOverrides: Record<string, unknown> = {}, memPalace: unknown
     ...dbOverrides
   };
 
-  return new ActuariusBot(config, logger, db as never, memPalace as never);
+  return new ActuariusBot(config, logger, db as never, memPalace as never, memPalaceRemote as never);
 }
 
 function createInteraction(overrides: Record<string, unknown> = {}) {
@@ -1040,6 +1044,56 @@ describe("ActuariusBot thread follow-ups", () => {
     expect(sent.some((message) => message.includes("done"))).toBe(true);
   });
 
+  it("injects the repository-specific MemPalace wing into queued provider prompts", async () => {
+    vi.mocked(ensureRepoCheckedOutToMaster).mockResolvedValue({ localPath: "/tmp/shotquill" });
+    vi.mocked(createRequestWorktree).mockResolvedValue({
+      path: "/tmp/worktree-shotquill",
+      branchName: "ask/102-123"
+    });
+    vi.mocked(runClaudeRequest).mockResolvedValue({ text: "done" });
+
+    const memPalaceRemote = {
+      registerRepository: vi.fn().mockResolvedValue("wing_shotquill"),
+      ensureWorktreeConfig: vi.fn().mockResolvedValue("wing_shotquill")
+    };
+    const thread = {
+      isThread: () => true,
+      send: vi.fn().mockResolvedValue(undefined),
+      messages: { fetch: vi.fn().mockResolvedValue(new Map()) }
+    };
+    const bot = createBot({
+      updateRequestStatus: vi.fn(),
+      updateRequestWorkspace: vi.fn()
+    }, null, memPalaceRemote);
+    (bot as any).client.channels.fetch = vi.fn().mockResolvedValue(thread);
+
+    await (bot as any).runQueuedRequest({
+      requestId: 102,
+      threadId: "thread-shotquill",
+      repoId: 2,
+      repo: {
+        owner: "DigitumDei",
+        repo: "ShotQuill",
+        fullName: "DigitumDei/ShotQuill"
+      },
+      prompt: "Implement the change",
+      provider: "claude"
+    });
+
+    expect(memPalaceRemote.ensureWorktreeConfig).toHaveBeenCalledWith(
+      {
+        owner: "DigitumDei",
+        repo: "ShotQuill",
+        fullName: "DigitumDei/ShotQuill"
+      },
+      "/tmp/worktree-shotquill"
+    );
+    const providerPrompt = vi.mocked(runClaudeRequest).mock.calls[0]![0].prompt;
+    expect(providerPrompt).toContain("Repository: DigitumDei/ShotQuill");
+    expect(providerPrompt).toContain("project memory wing for the repository being worked on is `wing_shotquill`");
+    expect(providerPrompt).not.toContain("`wing_actuarius`");
+  });
+
   it("exercises real buildMinimalExecutionEnvironment in queued ask path — auth vars, bin PATH, no arbitrary env", async () => {
     vi.mocked(ensureRepoCheckedOutToMaster).mockResolvedValue({ localPath: "/tmp/repo" });
     vi.mocked(createRequestWorktree).mockResolvedValue({
@@ -1661,6 +1715,32 @@ describe("ActuariusBot review runner selection", () => {
     expect(runners.judge.provider).toBe("claude");
     expect(runners.summarizer.provider).toBe("gemini");
     expect(runners.summarizer.model).toBe("gemini-2.5-pro");
+  });
+
+  it("propagates the resolved repository wing to review provider runs", async () => {
+    const bot = createBot({
+      getReviewerSlots: vi.fn().mockReturnValue([
+        { slot_index: 1, provider: "claude", model: null },
+        { slot_index: 2, provider: "gemini", model: null }
+      ])
+    });
+    (bot as any).runProviderText = vi.fn().mockResolvedValue("review output");
+
+    const runners = (bot as any).buildReviewRunners({
+      guildId: "guild-1",
+      repoId: 1,
+      memoryWing: "wing_shotquill"
+    });
+    await runners.reviewers[0].run({
+      prompt: "Review the change.",
+      cwd: "/tmp/worktree",
+      timeoutMs: 1_000
+    });
+
+    expect((bot as any).runProviderText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: "Review the change.",
+      memoryWing: "wing_shotquill"
+    }));
   });
 });
 
@@ -3706,7 +3786,7 @@ describe("ActuariusBot plan-oc command", () => {
     (bot as any).requestQueue.enqueue = enqueue;
     (bot as any).client.channels.fetch = vi.fn().mockResolvedValue(thread);
     (bot as any).prepareRepositoryMemory = vi.fn().mockResolvedValue(undefined);
-    (bot as any).prepareWorktreeMemoryConfig = vi.fn().mockResolvedValue(undefined);
+    (bot as any).prepareWorktreeMemoryConfig = vi.fn().mockResolvedValue("wing_hello_world");
     (bot as any).installService.buildMinimalExecutionEnvironment = vi.fn().mockReturnValue({
       packages: [],
       env: { GH_TOKEN: "test-token", OPENCODE_CONFIG_CONTENT: "untrusted-inline-config" }
@@ -3746,6 +3826,8 @@ describe("ActuariusBot plan-oc command", () => {
       }),
       logger
     );
+    expect(vi.mocked(runOpencodeAgentRequest).mock.calls[0]![0].prompt)
+      .toContain("project memory wing for the repository being worked on is `wing_hello_world`");
     expect(vi.mocked(runOpencodeAgentRequest).mock.calls[0]![0].env?.OPENCODE_CONFIG_CONTENT).toBeUndefined();
     expect(updateRequestStatus).toHaveBeenNthCalledWith(1, 121, "running");
     expect(updateRequestStatus).toHaveBeenLastCalledWith(121, "succeeded");
@@ -3989,6 +4071,7 @@ describe("ActuariusBot plan runner", () => {
     const send = vi.fn().mockResolvedValue(undefined);
     const updateRequestStatus = vi.fn();
     const bot = createBot({ updateRequestStatus });
+    (bot as any).prepareWorktreeMemoryConfig = vi.fn().mockResolvedValue("wing_hello_world");
     (bot as any).client.channels.fetch = vi.fn().mockResolvedValue({
       isThread: () => true,
       send
@@ -4017,9 +4100,11 @@ describe("ActuariusBot plan runner", () => {
     expect(planPrompt).toContain("Produce a structured implementation plan");
     expect(planPrompt).not.toContain("iterative");
     expect(planPrompt).not.toContain("Return ONLY valid JSON");
+    expect(runCalls[0]![0].memoryWing).toBe("wing_hello_world");
 
     const implPrompt = runCalls[1]![0].prompt;
     expect(implPrompt).toContain("Implement the request using the approved plan below");
+    expect(runCalls[1]![0].memoryWing).toBe("wing_hello_world");
 
     expect(updateRequestStatus).toHaveBeenCalledWith(92, "succeeded");
     expect(runIterativeTaskLoop).not.toHaveBeenCalled();
@@ -5416,6 +5501,7 @@ describe("ActuariusBot revise command", () => {
         isThread: () => true,
         send
       });
+      (bot as any).prepareWorktreeMemoryConfig = vi.fn().mockResolvedValue("wing_hello_world");
       (bot as any).runProviderText = vi.fn().mockResolvedValue(JSON.stringify({
         overview: "Fix bugs",
         tasks: [{ title: "Fix bug 1", description: "Fix the first bug" }]
@@ -5440,6 +5526,7 @@ describe("ActuariusBot revise command", () => {
       expect(runCalls.length).toBeGreaterThanOrEqual(1);
       for (const call of runCalls) {
         expect(call[0]).toHaveProperty("env");
+        expect(call[0].memoryWing).toBe("wing_hello_world");
         const env = call[0].env;
         expect(env.OPENAI_API_KEY).toBe("sk-openai-test");
         expect(env.GEMINI_API_KEY).toBe("gemini-test");

--- a/tests/llmPromptBuilders.test.ts
+++ b/tests/llmPromptBuilders.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { buildRepositoryMemoryScopedPrompt } from "../src/services/llmPromptBuilders.js";
+
+describe("buildRepositoryMemoryScopedPrompt", () => {
+  it("injects the exact dynamically resolved repository wing", () => {
+    const prompt = buildRepositoryMemoryScopedPrompt({
+      prompt: "Implement the requested change.",
+      memoryWing: "wing_shotquill"
+    });
+
+    expect(prompt).toContain("Implement the requested change.");
+    expect(prompt).toContain("project memory wing for the repository being worked on is `wing_shotquill`");
+    expect(prompt).toContain("Do not derive or invent a wing from the repository owner/name.");
+    expect(prompt).toContain("durable repository knowledge with `mempalace_add_drawer`");
+    expect(prompt).toContain("Project diary entries are local-only");
+  });
+
+  it("uses a different resolved wing without embedding an Actuarius-specific default", () => {
+    const prompt = buildRepositoryMemoryScopedPrompt({
+      prompt: "Review this repository.",
+      memoryWing: "wing_wellnesswingman"
+    });
+
+    expect(prompt).toContain("`wing_wellnesswingman`");
+    expect(prompt).not.toContain("`wing_actuarius`");
+  });
+
+  it("leaves prompts unchanged when repository memory is unavailable", () => {
+    expect(buildRepositoryMemoryScopedPrompt({
+      prompt: "Answer the question.",
+      memoryWing: null
+    })).toBe("Answer the question.");
+  });
+});


### PR DESCRIPTION
## Summary

- preserve the exact MemPalace project wing resolved from each repository's worktree configuration
- propagate that dynamic wing through `/ask`, follow-ups, `/plan`, iterative tasks, `/revise`, `/plan-oc`, and `/review`
- inject shared provider guidance to use the exact wing, store durable repository knowledge as drawers, and avoid owner/repository-derived wing names
- add prompt and workflow coverage for multiple repository wings

## Root cause

`MemPalaceRemoteService.ensureWorktreeConfig()` already returned the correct per-repository wing, but `prepareWorktreeMemoryConfig()` discarded it. Agents therefore had only a general instruction to inspect `mempalace.yaml` and could still invent wings such as `wing_digitumdei/actuarius`. Those project diary entries remained local by design and never reached the federated repository store.

## Impact

Every repository keeps its own configured project wing. Provider workflows now receive that resolved value explicitly without hard-coding Actuarius or deriving a wing from the repository owner/name.

## Validation

- `npm test` — 678 passed, 11 skipped
- `npm run build`
- `npm run check`
- `git diff --check`

Closes #176
