### PR TITLE
Block containers from GCE metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,14 @@ Infrastructure is managed via Terraform (`infra/`). VM instance metadata is the 
 
 SSH into the VM and run the helper script. **After `terraform apply`**, the local `/var/redeploy.sh` is stale — reboot or re-fetch it from metadata first:
 
+> **One-time upgrade gate:** if the existing production container still uses
+> Docker restart policy `unless-stopped`, do not reboot or redeploy yet. Run
+> `scripts/cutover-metadata-isolation.sh` on the VM first, using the exact
+> reviewed checkout that supplied the Terraform metadata. The script verifies
+> both payload hashes, changes the policy to `no`, stops the legacy container,
+> and only then declares reboot safe. See [docs/deploy.md](docs/deploy.md#mandatory-one-time-metadata-isolation-cutover)
+> for the required `gcloud compute scp` and SSH commands.
+
 ```bash
 # Re-fetch redeploy.sh from fresh metadata after terraform apply
 META="http://metadata.google.internal/computeMetadata/v1/instance/attributes"

--- a/README.md
+++ b/README.md
@@ -248,12 +248,13 @@ Infrastructure is managed via Terraform (`infra/`). VM instance metadata is the 
 SSH into the VM and run the helper script. **After `terraform apply`**, the local `/var/redeploy.sh` is stale — reboot or re-fetch it from metadata first:
 
 > **One-time upgrade gate:** if the existing production container still uses
-> Docker restart policy `unless-stopped`, do not reboot or redeploy yet. Run
-> `scripts/cutover-metadata-isolation.sh` on the VM first, using the exact
-> reviewed checkout that supplied the Terraform metadata. The script verifies
-> both payload hashes, changes the policy to `no`, stops the legacy container,
-> and only then declares reboot safe. See [docs/deploy.md](docs/deploy.md#mandatory-one-time-metadata-isolation-cutover)
-> for the required `gcloud compute scp` and SSH commands.
+> Docker restart policy `unless-stopped`, do not run a full `terraform apply`,
+> reboot, or redeploy yet. Publish only the two reviewed script payloads with
+> the documented non-stopping `gcloud compute instances add-metadata` command,
+> run `scripts/cutover-metadata-isolation.sh`, then reboot immediately and
+> verify the systemd units. Only after that is a full apply or redeploy safe.
+> See [docs/deploy.md](docs/deploy.md#mandatory-one-time-metadata-isolation-cutover)
+> for the required commands.
 
 ```bash
 # Re-fetch redeploy.sh from fresh metadata after terraform apply

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ services:
     memswap_limit: ${ACTUARIUS_CONTAINER_MEMORY_SWAP:-2g}
     cpus: ${ACTUARIUS_CONTAINER_CPUS:-0.8}
     pids_limit: ${ACTUARIUS_CONTAINER_PIDS_LIMIT:-1024}
-    restart: unless-stopped
+    # No restart policy: on the production VM, systemd (actuarius-bot.service,
+    # ordered after the metadata-isolation firewall unit) owns container
+    # lifecycle. Local compose usage starts containers explicitly.
+    restart: "no"
 
 volumes:
   actuarius_data:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -5,7 +5,7 @@ This document describes the deployment lifecycle for the Actuarius Discord bot o
 ## Overview
 
 ```
-terraform apply ──► updates metadata ──► guarded cutover (once) ──► reboot/redeploy ──► systemd starts container
+publish reviewed scripts ──► guarded cutover (once) ──► reboot + verify ──► terraform apply/redeploy
 ```
 
 The bot runs as a Docker container on a single GCE VM. Infrastructure is managed with Terraform; the application is deployed via a helper script fetched from instance metadata.
@@ -14,22 +14,38 @@ The bot runs as a Docker container on a single GCE VM. Infrastructure is managed
 
 The `infra/` directory defines the VM, disk, networking, and service account. Sensible values go in `terraform.tfvars` (gitignored — never commit secrets here).
 
-Apply with:
+Terraform writes all **non-secret** configuration into [instance metadata](https://cloud.google.com/compute/docs/metadata) — environment variables and the redeploy script itself (`env-redeploy-script`) — and creates empty [Secret Manager](https://cloud.google.com/secret-manager) containers for the secret values (see below).
+
+Before applying, inspect the plan. On an existing VM, a plan that changes a
+stop-required instance property may restart the VM because the instance allows
+stopping updates. If the legacy container still uses restart policy
+`unless-stopped`, complete the one-time cutover below **before** any full apply.
+After that cutover and its required reboot have been verified, apply normally:
 
 ```bash
 cd infra
+terraform plan
 terraform apply
 ```
-
-This writes all **non-secret** configuration into [instance metadata](https://cloud.google.com/compute/docs/metadata) — environment variables and the redeploy script itself (`env-redeploy-script`) — and creates empty [Secret Manager](https://cloud.google.com/secret-manager) containers for the secret values (see below). **It does not restart the VM or the container.**
 
 ### Mandatory one-time metadata-isolation cutover
 
 When upgrading a VM whose existing `actuarius` container still has Docker
-restart policy `unless-stopped`, do **not** reboot or redeploy immediately after
-`terraform apply`. Docker could auto-start that legacy container before the
-metadata firewall exists. From the same reviewed checkout that was applied,
-copy and run the hash-bound cutover first:
+restart policy `unless-stopped`, do **not** run a full `terraform apply`, reboot,
+or redeploy yet. A stopping Terraform update could reboot the VM and let Docker
+auto-start that legacy container before the metadata firewall exists.
+
+From the repository root of the exact reviewed checkout, first publish only the
+two hash-bound script payloads. `gcloud compute instances add-metadata` updates
+metadata in place and does not stop the VM:
+
+```bash
+gcloud compute instances add-metadata actuarius-bot \
+  --project <YOUR_PROJECT_ID> --zone <ZONE> \
+  --metadata-from-file=env-startup-script=infra/startup.sh,env-redeploy-script=scripts/redeploy.sh
+```
+
+Then copy and run the cutover:
 
 ```bash
 gcloud compute scp scripts/cutover-metadata-isolation.sh \
@@ -43,8 +59,30 @@ gcloud compute ssh actuarius-bot \
 
 The script refuses to mutate the container unless both published metadata
 payload hashes match its reviewed release. Success means the restart policy is
-`no` and the legacy container is stopped; only then is it safe to reboot. New
-VMs and already-migrated stopped containers are handled idempotently.
+`no` and the legacy container is stopped. **Reboot immediately; do not run the
+new redeploy payload in this gap**, because `startup.sh` has not installed the
+systemd units yet:
+
+```bash
+gcloud compute ssh actuarius-bot \
+  --project <YOUR_PROJECT_ID> --zone <ZONE> --tunnel-through-iap \
+  --command 'sudo reboot'
+```
+
+After the VM returns, verify the units and container before the full Terraform
+apply or any manual redeploy:
+
+```bash
+gcloud compute ssh actuarius-bot \
+  --project <YOUR_PROJECT_ID> --zone <ZONE> --tunnel-through-iap \
+  --command 'sudo systemctl --no-pager --full status actuarius-firewall.service actuarius-bot.service && sudo docker inspect -f "restart={{.HostConfig.RestartPolicy.Name}} running={{.State.Running}}" actuarius'
+```
+
+Both units must be active, and the container must report restart policy `no`
+and running state `true`. The full `terraform plan` / `terraform apply` may now proceed;
+any stop-required update is safe because Docker no longer owns container
+restart. New VMs and already-migrated stopped containers are handled
+idempotently; a brand-new VM may be created with the normal Terraform flow.
 
 ## Secrets
 
@@ -83,12 +121,8 @@ curl -sf -H "Metadata-Flavor: Google" "$META/env-redeploy-script" | sudo tee /va
 sudo bash /var/redeploy.sh
 ```
 
-After the mandatory cutover above has completed (or on an already-migrated
-VM), reboot so `startup.sh` handles it:
-
-```bash
-sudo reboot
-```
+The first reboot after the mandatory cutover is part of that procedure. Do not
+manually redeploy until it has installed and started the two systemd units.
 
 ## What redeploy.sh does
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -5,7 +5,7 @@ This document describes the deployment lifecycle for the Actuarius Discord bot o
 ## Overview
 
 ```
-terraform apply ──► updates metadata ──► reboot or curl ──► redeploy.sh ──► docker run
+terraform apply ──► updates metadata ──► guarded cutover (once) ──► reboot/redeploy ──► systemd starts container
 ```
 
 The bot runs as a Docker container on a single GCE VM. Infrastructure is managed with Terraform; the application is deployed via a helper script fetched from instance metadata.
@@ -22,6 +22,29 @@ terraform apply
 ```
 
 This writes all **non-secret** configuration into [instance metadata](https://cloud.google.com/compute/docs/metadata) — environment variables and the redeploy script itself (`env-redeploy-script`) — and creates empty [Secret Manager](https://cloud.google.com/secret-manager) containers for the secret values (see below). **It does not restart the VM or the container.**
+
+### Mandatory one-time metadata-isolation cutover
+
+When upgrading a VM whose existing `actuarius` container still has Docker
+restart policy `unless-stopped`, do **not** reboot or redeploy immediately after
+`terraform apply`. Docker could auto-start that legacy container before the
+metadata firewall exists. From the same reviewed checkout that was applied,
+copy and run the hash-bound cutover first:
+
+```bash
+gcloud compute scp scripts/cutover-metadata-isolation.sh \
+  actuarius-bot:/tmp/cutover-metadata-isolation.sh \
+  --project <YOUR_PROJECT_ID> --zone <ZONE> --tunnel-through-iap
+
+gcloud compute ssh actuarius-bot \
+  --project <YOUR_PROJECT_ID> --zone <ZONE> --tunnel-through-iap \
+  --command 'sudo bash /tmp/cutover-metadata-isolation.sh'
+```
+
+The script refuses to mutate the container unless both published metadata
+payload hashes match its reviewed release. Success means the restart policy is
+`no` and the legacy container is stopped; only then is it safe to reboot. New
+VMs and already-migrated stopped containers are handled idempotently.
 
 ## Secrets
 
@@ -60,7 +83,8 @@ curl -sf -H "Metadata-Flavor: Google" "$META/env-redeploy-script" | sudo tee /va
 sudo bash /var/redeploy.sh
 ```
 
-Or reboot the VM so `startup.sh` handles it:
+After the mandatory cutover above has completed (or on an already-migrated
+VM), reboot so `startup.sh` handles it:
 
 ```bash
 sudo reboot
@@ -71,7 +95,9 @@ sudo reboot
 1. Reads non-secret config from metadata (`env-discord-client-id`, `env-enable-codex-execution`, etc.) and secret values from Secret Manager (`actuarius-discord-token`, etc.) using the VM service account's access token
 2. Pulls the Docker image (`ghcr.io/digitumdei/actuarius:latest` or a specific SHA tag)
 3. Stops and removes the old container
-4. Starts a new container with the correct env vars mapped from metadata
+4. Creates a new `restart=no` container with the correct env vars
+5. Starts it through `actuarius-bot.service`, whose pre-start gate revalidates
+   metadata isolation every time the container starts
 
 Production deploys constrain the container to 700 MB RAM, 2 GB memory+swap,
 0.8 CPU, and 1024 tasks by default. These cgroup limits keep provider builds

--- a/infra/compute.tf
+++ b/infra/compute.tf
@@ -85,6 +85,14 @@ resource "google_compute_instance" "actuarius" {
 
   service_account {
     email  = google_service_account.actuarius_bot.email
+    # cloud-platform is deliberate: Secret Manager's REST API accepts no
+    # narrower OAuth scope for AccessSecretVersion, and redeploy.sh fetches
+    # secrets host-side with this token at deploy time. Least privilege is
+    # enforced by IAM instead (iam.tf: logWriter + secretAccessor only) and
+    # by infra/startup.sh, which routes container traffic through a dedicated
+    # ACTUARIUS-METADATA iptables chain jumped from the top of DOCKER-USER —
+    # installed before docker starts containers — so a compromised container
+    # can never reach the metadata server to mint a token at all.
     scopes = ["cloud-platform"]
   }
 

--- a/infra/startup.sh
+++ b/infra/startup.sh
@@ -143,6 +143,31 @@ docker_user_first_target() {
     | grep -E '^[[:space:]]*[0-9]+[[:space:]]' | head -n 1 | awk '{print $2}'
 }
 
+# First referenced managed generation anywhere in DOCKER-USER. A rule above
+# it may itself be drift, but the referenced generation must remain attached
+# until a complete replacement has been installed at rule 1.
+docker_user_first_managed_target() {
+  LC_ALL=C iptables -w -nL DOCKER-USER --line-numbers 2>/dev/null \
+    | awk -v a="$GEN_A" -v b="$GEN_B" \
+      '/^[[:space:]]*[0-9]+[[:space:]]/ && ($2 == a || $2 == b) { print $2; exit }'
+}
+
+managed_target_present() {
+  local target="$1"
+  LC_ALL=C iptables -w -nL DOCKER-USER --line-numbers 2>/dev/null \
+    | awk -v target="$target" \
+      '/^[[:space:]]*[0-9]+[[:space:]]/ && $2 == target { found=1 } END { exit !found }'
+}
+
+# Docker normally installs this as the first FORWARD rule. Accepting a
+# conditional or shadowed occurrence would let some container traffic bypass
+# DOCKER-USER entirely, so require the exact unconditional first rule.
+forward_jump_is_unconditional_first() {
+  local line
+  line=$(iptables -S FORWARD 2>/dev/null | grep -- '-A FORWARD ' | head -n 1 || true)
+  [ "$line" = "-A FORWARD -j DOCKER-USER" ]
+}
+
 # Rule 1 must be EXACTLY an unconditional jump. The -nL target column cannot
 # distinguish `-j GEN` from `-p tcp -j GEN` (both report target GEN), so the
 # fast path would accept conditional jumps that let UDP bypass policy. A
@@ -171,6 +196,24 @@ purge_rule() {
   return 0
 }
 
+# Remove every conditional or unconditional rule that targets a managed
+# generation. The rule is round-tripped from iptables -S so deletion uses its
+# canonical form. Callers keep another complete generation referenced until
+# this returns successfully.
+purge_managed_target() {
+  local target="$1" line spec i=0
+  while [ "$i" -lt 10 ]; do
+    line=$(iptables -S DOCKER-USER 2>/dev/null \
+      | grep -E -- "^-A DOCKER-USER (.* )?-j $target$" | head -n 1 || true)
+    [ -n "$line" ] || break
+    spec="${line#-A DOCKER-USER }"
+    iptables -w -D DOCKER-USER $spec 2>/dev/null || break
+    i=$((i + 1))
+  done
+  managed_target_present "$target" && return 1
+  return 0
+}
+
 legacy_rules_absent() {
   local spec
   for spec in "${LEGACY_SPECS[@]}"; do
@@ -191,10 +234,10 @@ build_generation() {
 }
 
 harden_metadata_access() {
-  local attempts=60 current target source spec
+  local attempts=60 first target source spec
   until systemctl is-active --quiet docker \
     && iptables -w -nL DOCKER-USER >/dev/null 2>&1 \
-    && iptables -S FORWARD 2>/dev/null | grep -q -- '-j DOCKER-USER'; do
+    && forward_jump_is_unconditional_first; do
     attempts=$((attempts - 1))
     if [ "$attempts" -le 0 ]; then
       fatal "docker/DOCKER-USER chain not ready in time"
@@ -203,8 +246,9 @@ harden_metadata_access() {
     sleep 1
   done
 
-  current="$(docker_user_first_target)"
-  case "$current" in
+  first="$(docker_user_first_target)"
+  source="$(docker_user_first_managed_target)"
+  case "$source" in
     "$GEN_A") source="$GEN_A"; target="$GEN_B" ;;
     "$GEN_B") source="$GEN_B"; target="$GEN_A" ;;
     *) source=""; target="$GEN_A" ;;
@@ -214,27 +258,30 @@ harden_metadata_access() {
     && content_ok "$source" \
     && jump_is_unconditional_first "$source" \
     && legacy_rules_absent \
-    && ! iptables -w -C DOCKER-USER -j "$target" 2>/dev/null; then
+    && ! managed_target_present "$target"; then
     return 0
   fi
 
-  # Rebuild into the unreferenced generation, then flip atomically.
+  # Keep the first referenced managed generation attached while rebuilding.
+  # Even when drift precedes it, removing that last policy before a successful
+  # replacement would create a new exposure window and leave it open forever
+  # if population failed.
   if [ -n "$source" ]; then
-    purge_rule DOCKER-USER -j "$target" || { fatal "cannot detach $target"; return 1; }
+    purge_managed_target "$target" || { fatal "cannot detach $target"; return 1; }
   else
-    purge_rule DOCKER-USER -j "$GEN_A" || { fatal "cannot detach $GEN_A"; return 1; }
-    purge_rule DOCKER-USER -j "$GEN_B" || { fatal "cannot detach $GEN_B"; return 1; }
+    purge_managed_target "$GEN_A" || { fatal "cannot detach $GEN_A"; return 1; }
+    purge_managed_target "$GEN_B" || { fatal "cannot detach $GEN_B"; return 1; }
   fi
   build_generation "$target" || { fatal "could not build $target"; return 1; }
 
-  if [ -n "$source" ]; then
+  if [ -n "$source" ] && [ "$first" = "$source" ]; then
     iptables -w -R DOCKER-USER 1 -j "$target" || { fatal "could not switch the jump"; return 1; }
   else
     iptables -w -I DOCKER-USER 1 -j "$target" || { fatal "could not install the jump"; return 1; }
   fi
 
   if [ -n "$source" ]; then
-    purge_rule DOCKER-USER -j "$source" || { fatal "cannot retire $source"; return 1; }
+    purge_managed_target "$source" || { fatal "cannot retire $source"; return 1; }
     iptables -w -F "$source" 2>/dev/null || true
     iptables -w -X "$source" 2>/dev/null || true
   fi
@@ -247,7 +294,7 @@ harden_metadata_access() {
   jump_is_unconditional_first "$target" || { fatal "jump is not an unconditional first rule after repair"; return 1; }
   legacy_rules_absent || { fatal "legacy metadata rules survive in DOCKER-USER"; return 1; }
   if [ -n "$source" ]; then
-    iptables -w -C DOCKER-USER -j "$source" 2>/dev/null && { fatal "$source jump survives after repair"; return 1; }
+    managed_target_present "$source" && { fatal "$source jump survives after repair"; return 1; }
   fi
   return 0
 }
@@ -283,6 +330,7 @@ After=docker.service actuarius-firewall.service
 
 [Service]
 Type=simple
+ExecStartPre=/bin/bash ${BOOTSTRAP}
 ExecStart=/usr/bin/docker start -a actuarius
 ExecStop=/usr/bin/docker stop -t 30 actuarius
 Restart=always

--- a/infra/startup.sh
+++ b/infra/startup.sh
@@ -44,6 +44,262 @@ if [ ! -f "$SWAP" ]; then
 fi
 swapon "$SWAP" 2>/dev/null || true
 
+# --- Block containers from reaching the GCP metadata server ---
+# A prompt-injected agent must never mint a GCP access token: the VM service
+# account holds secretmanager.secretAccessor on every bot secret, so a single
+# unauthenticated HTTP call to 169.254.169.254 from inside the container is
+# total compromise (security review 2026-08-24, finding C-1).
+#
+# Boot model on COS (validated against production 2026-08-25): /etc is
+# STATELESS on Container-Optimized OS — unit files and `systemctl enable`
+# symlinks written here do NOT survive a reboot. Nothing about the units
+# below is persistent; this script recreates them on every boot.
+#   1. docker.service starts; dockerd creates DOCKER-USER and its FORWARD
+#      jump. The bot container does NOT autostart: its restart policy is
+#      "no". Legacy containers created before this design carry
+#      unless-stopped and MUST be migrated first — see
+#      scripts/cutover-metadata-isolation.sh, which flips the policy,
+#      stops the container, and gates the reboot on both checkpoints.
+#   2. google-startup-scripts runs THIS script: it writes the bootstrap and
+#      both unit definitions into the fresh /etc, daemon-reloads, enables
+#      them for this boot, and converges any drift by running the bootstrap
+#      directly against the now-existing Docker chains.
+#   3. Within this boot, actuarius-firewall.service wraps the same
+#      bootstrap (Requires+After=docker.service) and actuarius-bot.service
+#      Requires+Afters both — so the container starts only after verified
+#      isolation, and a failed bootstrap keeps the bot down entirely
+#      (fail closed).
+#   4. The script finishes by redeploying, which starts the container
+#      through `systemctl restart actuarius-bot.service`.
+#
+# Packet path once installed:
+#   container -> FORWARD -> DOCKER-USER(rule 1: -j ACTUARIUS-META-A|B)
+#     tcp|udp dpt 53 -> 169.254.169.254/32 : RETURN (container DNS works;
+#       GCE resolves via the metadata address)
+#     any other metadata traffic           : DROP
+#     everything else                      : implicit return, normal traversal
+#
+# Repair transitions are exposure-free by construction: policy lives in two
+# private generations; repairs populate the UNREFERENCED generation, switch
+# the jump with ONE atomic rule operation, and only then touch the retired
+# generation. The referenced chain is never flushed. Verification uses
+# semantic probes (iptables -C membership, -nL row counts/target columns
+# under LC_ALL=C) instead of -S text comparison, which real backends
+# canonicalize unpredictably — with one exception: rule 1 must be an
+# UNCONDITIONAL jump, and a conditionless rule serializes identically on
+# every backend, so exact -S equality is used there. Absence of the legacy
+# inline rules from older versions of this script is itself load-bearing —
+# a surviving legacy DROP below the jump would break container DNS after a
+# RETURN — so their removal is verified, not assumed.
+EARLY_DIR="/etc/actuarius"
+BOOTSTRAP="$EARLY_DIR/metadata-firewall-bootstrap.sh"
+FIREWALL_UNIT="/etc/systemd/system/actuarius-firewall.service"
+BOT_UNIT="/etc/systemd/system/actuarius-bot.service"
+mkdir -p "$EARLY_DIR"
+
+cat > "$BOOTSTRAP" <<'METADATA_FIREWALL_EOF'
+#!/bin/bash
+# Metadata-isolation engine for Actuarius (see infra/startup.sh for the boot
+# model). Invoked by actuarius-firewall.service after docker.service, and
+# directly by startup.sh for post-boot convergence. Idempotent; fail-closed.
+set -euo pipefail
+
+METADATA_IP="169.254.169.254"
+GEN_A="ACTUARIUS-META-A"
+GEN_B="ACTUARIUS-META-B"
+LEGACY_SPECS=(
+  "-d 169.254.169.254/32 -j DROP"
+  "-p udp -d 169.254.169.254/32 --dport 53 -j ACCEPT"
+  "-p tcp -d 169.254.169.254/32 --dport 53 -j ACCEPT"
+)
+GEN_RULES=(
+  "-p tcp -d 169.254.169.254/32 --dport 53 -j RETURN"
+  "-p udp -d 169.254.169.254/32 --dport 53 -j RETURN"
+  "-d 169.254.169.254/32 -j DROP"
+)
+
+fatal() {
+  echo "FATAL: $*; refusing to continue without metadata isolation" >&2
+}
+
+# Semantic content check: exactly three rules, all three expected specs
+# present, and the last rule's target is DROP. Uses -C (canonicalization-
+# immune) and -nL columns under LC_ALL=C — never -S text comparison.
+content_ok() {
+  local gen="$1" rows last_target spec
+  rows=$(LC_ALL=C iptables -w -nL "$gen" --line-numbers 2>/dev/null | grep -cE '^[[:space:]]*[0-9]+[[:space:]]' || true)
+  [ "$rows" = "3" ] || return 1
+  for spec in "${GEN_RULES[@]}"; do
+    iptables -w -C "$gen" $spec 2>/dev/null || return 1
+  done
+  last_target=$(LC_ALL=C iptables -w -nL "$gen" --line-numbers 2>/dev/null | grep -E '^[[:space:]]*[0-9]+[[:space:]]' | tail -n 1 | awk '{print $2}')
+  [ "$last_target" = "DROP" ]
+}
+
+# Target name of the FIRST rule of DOCKER-USER (a chain name when the rule
+# is a jump). Canonicalization-immune: reads the -nL target column.
+docker_user_first_target() {
+  LC_ALL=C iptables -w -nL DOCKER-USER --line-numbers 2>/dev/null \
+    | grep -E '^[[:space:]]*[0-9]+[[:space:]]' | head -n 1 | awk '{print $2}'
+}
+
+# Rule 1 must be EXACTLY an unconditional jump. The -nL target column cannot
+# distinguish `-j GEN` from `-p tcp -j GEN` (both report target GEN), so the
+# fast path would accept conditional jumps that let UDP bypass policy. A
+# conditionless rule has no match fields to canonicalize, so its serialized
+# form is definitionally `-A DOCKER-USER -j GEN` on every backend — exact
+# equality is safe precisely here, and only here.
+jump_is_unconditional_first() {
+  local gen="$1" line
+  line=$(iptables -S DOCKER-USER 2>/dev/null | grep -- '-A DOCKER-USER ' | head -n 1)
+  [ "$line" = "-A DOCKER-USER -j $gen" ]
+}
+
+# Every occurrence of a rule must be gone when its absence is load-bearing.
+# Bounded loop distinguishes "absent" from "stuck": persistent presence is a
+# failure, not completion.
+purge_rule() {
+  local chain="$1" i=0 spec
+  shift
+  spec="$*"
+  while [ "$i" -lt 10 ]; do
+    iptables -w -C "$chain" $spec 2>/dev/null || break
+    iptables -w -D "$chain" $spec 2>/dev/null || break
+    i=$((i + 1))
+  done
+  iptables -w -C "$chain" $spec 2>/dev/null && return 1
+  return 0
+}
+
+legacy_rules_absent() {
+  local spec
+  for spec in "${LEGACY_SPECS[@]}"; do
+    iptables -w -C DOCKER-USER $spec 2>/dev/null && return 1
+  done
+  return 0
+}
+
+build_generation() {
+  # Caller guarantees the generation is unreferenced, so flushing partial
+  # state here can never expose live traffic.
+  local gen="$1" spec
+  iptables -w -N "$gen" 2>/dev/null || true
+  iptables -w -F "$gen" || return 1
+  for spec in "${GEN_RULES[@]}"; do
+    iptables -w -A "$gen" $spec || return 1
+  done
+}
+
+harden_metadata_access() {
+  local attempts=60 current target source spec
+  until systemctl is-active --quiet docker \
+    && iptables -w -nL DOCKER-USER >/dev/null 2>&1 \
+    && iptables -S FORWARD 2>/dev/null | grep -q -- '-j DOCKER-USER'; do
+    attempts=$((attempts - 1))
+    if [ "$attempts" -le 0 ]; then
+      fatal "docker/DOCKER-USER chain not ready in time"
+      return 1
+    fi
+    sleep 1
+  done
+
+  current="$(docker_user_first_target)"
+  case "$current" in
+    "$GEN_A") source="$GEN_A"; target="$GEN_B" ;;
+    "$GEN_B") source="$GEN_B"; target="$GEN_A" ;;
+    *) source=""; target="$GEN_A" ;;
+  esac
+
+  if [ -n "$source" ] \
+    && content_ok "$source" \
+    && jump_is_unconditional_first "$source" \
+    && legacy_rules_absent \
+    && ! iptables -w -C DOCKER-USER -j "$target" 2>/dev/null; then
+    return 0
+  fi
+
+  # Rebuild into the unreferenced generation, then flip atomically.
+  if [ -n "$source" ]; then
+    purge_rule DOCKER-USER -j "$target" || { fatal "cannot detach $target"; return 1; }
+  else
+    purge_rule DOCKER-USER -j "$GEN_A" || { fatal "cannot detach $GEN_A"; return 1; }
+    purge_rule DOCKER-USER -j "$GEN_B" || { fatal "cannot detach $GEN_B"; return 1; }
+  fi
+  build_generation "$target" || { fatal "could not build $target"; return 1; }
+
+  if [ -n "$source" ]; then
+    iptables -w -R DOCKER-USER 1 -j "$target" || { fatal "could not switch the jump"; return 1; }
+  else
+    iptables -w -I DOCKER-USER 1 -j "$target" || { fatal "could not install the jump"; return 1; }
+  fi
+
+  if [ -n "$source" ]; then
+    purge_rule DOCKER-USER -j "$source" || { fatal "cannot retire $source"; return 1; }
+    iptables -w -F "$source" 2>/dev/null || true
+    iptables -w -X "$source" 2>/dev/null || true
+  fi
+  for spec in "${LEGACY_SPECS[@]}"; do
+    purge_rule DOCKER-USER $spec || { fatal "cannot remove legacy rule ($*)"; return 1; }
+  done
+
+  # Post-repair gate: trust nothing above, including our own mutations.
+  content_ok "$target" || { fatal "post-repair verification of $target failed"; return 1; }
+  jump_is_unconditional_first "$target" || { fatal "jump is not an unconditional first rule after repair"; return 1; }
+  legacy_rules_absent || { fatal "legacy metadata rules survive in DOCKER-USER"; return 1; }
+  if [ -n "$source" ]; then
+    iptables -w -C DOCKER-USER -j "$source" 2>/dev/null && { fatal "$source jump survives after repair"; return 1; }
+  fi
+  return 0
+}
+METADATA_FIREWALL_EOF
+
+cat >> "$BOOTSTRAP" <<'METADATA_FIREWALL_GUARD_EOF'
+
+harden_metadata_access || exit 1
+METADATA_FIREWALL_GUARD_EOF
+chmod 700 "$BOOTSTRAP"
+
+cat > "$FIREWALL_UNIT" <<EOF
+[Unit]
+Description=Actuarius metadata-server isolation (requires Docker chains)
+Requires=docker.service
+After=docker.service
+Before=actuarius-bot.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash ${BOOTSTRAP}
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > "$BOT_UNIT" <<EOF
+[Unit]
+Description=Actuarius bot container lifecycle (owned by systemd)
+Requires=docker.service actuarius-firewall.service
+After=docker.service actuarius-firewall.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/docker start -a actuarius
+ExecStop=/usr/bin/docker stop -t 30 actuarius
+Restart=always
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# COS /etc is stateless: these files are recreated on every boot by this
+# script, so enablement is per-boot by construction.
+systemctl daemon-reload
+systemctl enable actuarius-firewall.service actuarius-bot.service >/dev/null
+
+# Converge this boot's drift through the exact code the firewall unit runs.
+bash "$BOOTSTRAP"
+
 # --- Install redeploy helper script from metadata ---
 # Note: /var is mounted noexec on COS, so scripts must be invoked with `bash`
 META="http://metadata.google.internal/computeMetadata/v1/instance/attributes"

--- a/infra/startup.sh
+++ b/infra/startup.sh
@@ -311,6 +311,7 @@ cat > "$FIREWALL_UNIT" <<EOF
 Description=Actuarius metadata-server isolation (requires Docker chains)
 Requires=docker.service
 After=docker.service
+PartOf=docker.service
 Before=actuarius-bot.service
 
 [Service]
@@ -327,6 +328,7 @@ cat > "$BOT_UNIT" <<EOF
 Description=Actuarius bot container lifecycle (owned by systemd)
 Requires=docker.service actuarius-firewall.service
 After=docker.service actuarius-firewall.service
+PartOf=docker.service
 
 [Service]
 Type=simple

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "check": "tsc --noEmit -p tsconfig.json",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
-    "test": "vitest run"
+    "test": "vitest run --exclude \"**/.worktrees/**\""
   },
   "engines": {
     "node": ">=22"

--- a/scripts/cutover-metadata-isolation.sh
+++ b/scripts/cutover-metadata-isolation.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# One-time cutover to the systemd-owned container lifecycle with metadata
+# isolation (security review 2026-08-24, finding C-1).
+#
+# Run ON THE VM (IAP SSH) AFTER `terraform apply` has published the new
+# env-startup-script metadata and BEFORE the first reboot. Until this runs,
+# the legacy container still carries `unless-stopped` and would auto-start
+# unprotected at boot — rebooting before this cutover completes is unsafe.
+#
+# Ordered fail-closed preconditions:
+#   1. Docker daemon must answer (`docker info`). An unreachable daemon is
+#      NEVER reported as "nothing to migrate".
+#   2. BOTH env-startup-script and env-redeploy-script metadata payloads are
+#      fetched to disk (raw bytes preserved) and their SHA-256 digests are
+#      compared against the EXPECTED_* constants below BEFORE any mutation.
+#      Those constants bind this script to the exact independently reviewed
+#      infra/startup.sh and scripts/redeploy.sh of its own commit — structural
+#      markers alone cannot distinguish a known-vulnerable prior revision.
+#      Missing payloads, HTTP errors, partial publication, or stale content
+#      all abort — so a completed run can never be followed by a reboot into
+#      the old lifecycle. Regenerate the constants whenever either file
+#      changes: sha256sum infra/startup.sh scripts/redeploy.sh
+#
+# Idempotent and resumable: safe to re-run; exits 0 immediately once
+# migrated, and resumes safely from an interrupted run (policy already 'no',
+# container still up) without repeating the update.
+set -euo pipefail
+
+CONTAINER="actuarius"
+MDS="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+
+# Release identity — SHA-256 of infra/startup.sh and scripts/redeploy.sh at
+# the reviewed commit this script ships with. Update both together with any
+# change to those files.
+EXPECTED_STARTUP_SHA256="83d8cfe62d74a140e1a936ad942370a3834bba0d3a6185479433bdba19b92122"
+EXPECTED_REDEPLOY_SHA256="e7e869b55b3f12e03a624cb7eea9247667f1ae6e27b341a9617684603c480d00"
+
+fail() {
+  echo "FATAL: $*" >&2
+  exit 1
+}
+
+echo "0/6 Checking Docker daemon health..."
+docker info >/dev/null 2>&1 || fail "docker daemon unavailable; refusing to reason about migration state"
+
+echo "1/6 Verifying published metadata against the reviewed release..."
+TMP_STARTUP=$(mktemp)
+TMP_REDEPLOY=$(mktemp)
+trap 'rm -f "$TMP_STARTUP" "$TMP_REDEPLOY"' EXIT
+
+fetch_and_hash() {
+  local url="$1" out="$2" expected="$3" label="$4" actual
+  curl -sf -m 10 -H "Metadata-Flavor: Google" "$url" -o "$out" \
+    || fail "could not fetch $label metadata (has 'terraform apply' been run?)"
+  actual=$(sha256sum "$out" | awk '{print $1}')
+  [ -n "$expected" ] || fail "expected hash for $label is not configured"
+  [ "$actual" = "$expected" ] \
+    || fail "published $label payload does not match the reviewed release (hash mismatch; stale or partial publication)"
+}
+
+fetch_and_hash "$MDS/env-startup-script" "$TMP_STARTUP" "$EXPECTED_STARTUP_SHA256" "env-startup-script"
+fetch_and_hash "$MDS/env-redeploy-script" "$TMP_REDEPLOY" "$EXPECTED_REDEPLOY_SHA256" "env-redeploy-script"
+
+restart_policy() {
+  docker inspect -f '{{.HostConfig.RestartPolicy.Name}}' "$CONTAINER" 2>/dev/null
+}
+
+is_running() {
+  docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null
+}
+
+echo "2/6 Checking existing container state..."
+inspect_out=""
+inspect_status=0
+inspect_out=$(docker inspect "$CONTAINER" 2>&1) || inspect_status=$?
+if [ "$inspect_status" -ne 0 ]; then
+  if printf '%s' "$inspect_out" | grep -q "No such object"; then
+    echo "Verified safe: no '$CONTAINER' container exists (daemon healthy, new lifecycle published)."
+    exit 0
+  fi
+  fail "docker inspect failed unexpectedly: $inspect_out"
+fi
+
+CURRENT_POLICY="$(restart_policy)" || fail "could not read restart policy"
+IS_RUNNING="$(is_running)" || fail "could not read container state"
+
+if [ "$CURRENT_POLICY" = "no" ] && [ "$IS_RUNNING" = "false" ]; then
+  echo "Already migrated: restart policy 'no' and container stopped."
+  exit 0
+fi
+
+echo "3/6 Flipping restart policy to 'no'..."
+if [ "$CURRENT_POLICY" != "no" ]; then
+  if [ "$CURRENT_POLICY" != "unless-stopped" ]; then
+    fail "unexpected current restart policy '$CURRENT_POLICY'; inspect manually before proceeding"
+  fi
+  docker update --restart=no "$CONTAINER" || fail "docker update failed"
+else
+  # Resumable intermediate state from a previous failed run: the policy is
+  # already correct but the container is still up. Skip the update.
+  echo "    policy already 'no'; resuming interrupted migration"
+fi
+
+echo "4/6 Verifying restart policy..."
+[ "$(restart_policy)" = "no" ] || fail "restart policy did not take effect"
+
+echo "5/6 Stopping the legacy container..."
+docker stop "$CONTAINER" >/dev/null || true
+
+echo "6/6 Verifying the container is stopped..."
+[ "$(is_running)" = "false" ] || fail "container is still running after stop"
+
+echo "Cutover complete: restart policy 'no', container stopped."
+echo "It is now safe to reboot. After the reboot verify:"
+echo "  systemctl status actuarius-firewall.service actuarius-bot.service"
+echo "  docker exec $CONTAINER getent hosts metadata.google.internal   # must resolve (DNS)"
+echo "  docker exec $CONTAINER curl -sf -m 3 -H 'Metadata-Flavor: Google' \\"
+echo "    http://metadata.google.internal/computeMetadata/v1/project/project-id  # must FAIL"

--- a/scripts/cutover-metadata-isolation.sh
+++ b/scripts/cutover-metadata-isolation.sh
@@ -32,7 +32,7 @@ MDS="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
 # Release identity — SHA-256 of infra/startup.sh and scripts/redeploy.sh at
 # the reviewed commit this script ships with. Update both together with any
 # change to those files.
-EXPECTED_STARTUP_SHA256="83d8cfe62d74a140e1a936ad942370a3834bba0d3a6185479433bdba19b92122"
+EXPECTED_STARTUP_SHA256="73ca09fec39d3334d81487403785dce96e94b3f9b5c077cdaefe33865e26fdf3"
 EXPECTED_REDEPLOY_SHA256="e7e869b55b3f12e03a624cb7eea9247667f1ae6e27b341a9617684603c480d00"
 
 fail() {

--- a/scripts/cutover-metadata-isolation.sh
+++ b/scripts/cutover-metadata-isolation.sh
@@ -2,10 +2,12 @@
 # One-time cutover to the systemd-owned container lifecycle with metadata
 # isolation (security review 2026-08-24, finding C-1).
 #
-# Run ON THE VM (IAP SSH) AFTER `terraform apply` has published the new
-# env-startup-script metadata and BEFORE the first reboot. Until this runs,
-# the legacy container still carries `unless-stopped` and would auto-start
-# unprotected at boot — rebooting before this cutover completes is unsafe.
+# Run ON THE VM (IAP SSH) after the two reviewed script payloads have been
+# published with the non-stopping `gcloud compute instances add-metadata`
+# command documented in docs/deploy.md, and BEFORE any full Terraform apply
+# or reboot. Until this runs, the legacy container still carries
+# `unless-stopped` and would auto-start unprotected at boot — rebooting before
+# this cutover completes is unsafe.
 #
 # Ordered fail-closed preconditions:
 #   1. Docker daemon must answer (`docker info`). An unreachable daemon is
@@ -32,8 +34,8 @@ MDS="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
 # Release identity — SHA-256 of infra/startup.sh and scripts/redeploy.sh at
 # the reviewed commit this script ships with. Update both together with any
 # change to those files.
-EXPECTED_STARTUP_SHA256="73ca09fec39d3334d81487403785dce96e94b3f9b5c077cdaefe33865e26fdf3"
-EXPECTED_REDEPLOY_SHA256="e7e869b55b3f12e03a624cb7eea9247667f1ae6e27b341a9617684603c480d00"
+EXPECTED_STARTUP_SHA256="ec74a0c4c7e01ea94f37dbd73552bab8751018e7d21cae30cfc1109649fe2a80"
+EXPECTED_REDEPLOY_SHA256="ff039d7aaba92e3e5a05241f465be0995950890d72eab7a1843ddbfceeda85cb"
 
 fail() {
   echo "FATAL: $*" >&2
@@ -51,7 +53,7 @@ trap 'rm -f "$TMP_STARTUP" "$TMP_REDEPLOY"' EXIT
 fetch_and_hash() {
   local url="$1" out="$2" expected="$3" label="$4" actual
   curl -sf -m 10 -H "Metadata-Flavor: Google" "$url" -o "$out" \
-    || fail "could not fetch $label metadata (has 'terraform apply' been run?)"
+    || fail "could not fetch $label metadata (have the reviewed payloads been published?)"
   actual=$(sha256sum "$out" | awk '{print $1}')
   [ -n "$expected" ] || fail "expected hash for $label is not configured"
   [ "$actual" = "$expected" ] \

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -217,6 +217,15 @@ if [ -n "$GEMINI_API_KEY" ]; then
   EXTRA_ARGS+=(-e "GEMINI_API_KEY=$GEMINI_API_KEY")
 fi
 
+# A first-rollout cutover deliberately stops the legacy container before the
+# reboot that installs these units. Refuse to remove that container if an
+# operator accidentally invokes the freshly published redeploy payload in the
+# gap: systemctl cannot start a unit that startup.sh has not installed yet.
+systemctl cat actuarius-firewall.service actuarius-bot.service >/dev/null 2>&1 || {
+  echo "FATAL: Actuarius systemd units are not installed; complete the metadata-isolation cutover and reboot before redeploying" >&2
+  exit 1
+}
+
 docker pull "$IMAGE"
 docker rm -f actuarius 2>/dev/null || true
 mkdir -p "$DATA_ROOT/home/appuser"

--- a/scripts/redeploy.sh
+++ b/scripts/redeploy.sh
@@ -222,9 +222,12 @@ docker rm -f actuarius 2>/dev/null || true
 mkdir -p "$DATA_ROOT/home/appuser"
 chown -R 1001:1001 "$DATA_ROOT/home"
 
-docker run -d \
+# The container is CREATED but not started: systemd owns its lifecycle via
+# actuarius-bot.service, which is ordered after actuarius-firewall.service so
+# the bot can never run before metadata isolation is effective. No restart
+# policy — restarts on crash and at boot are systemd's job now.
+docker create \
   --name actuarius \
-  --restart unless-stopped \
   --memory "$CONTAINER_MEMORY" \
   --memory-swap "$CONTAINER_MEMORY_SWAP" \
   --cpus "$CONTAINER_CPUS" \
@@ -240,4 +243,5 @@ docker run -d \
   -e LOG_LEVEL=info \
   "$IMAGE"
 docker image prune -f
+systemctl restart actuarius-bot.service
 echo "Done. Logs: docker logs -f actuarius"

--- a/tests/redeployScript.test.ts
+++ b/tests/redeployScript.test.ts
@@ -12,6 +12,7 @@ type RunResult = {
   stdout: string;
   stderr: string;
   dockerLog: string;
+  systemctlLog: string;
 };
 
 const repoRoot = process.cwd();
@@ -121,6 +122,16 @@ exit 0
 `;
 }
 
+function createSystemctlMock(logPath: string): string {
+  return `#!/usr/bin/env bash
+for arg in "$@"; do
+  printf '%s ' "$arg" >> ${shellSingleQuote(logPath)}
+done
+printf '\\n' >> ${shellSingleQuote(logPath)}
+exit 0
+`;
+}
+
 function runRedeploy(metadata: Metadata, secrets: Secrets = baseSecrets): RunResult {
   const tempDir = mkdtempSync(join(tmpdir(), "redeploy-test-"));
   tempDirs.push(tempDir);
@@ -130,12 +141,14 @@ function runRedeploy(metadata: Metadata, secrets: Secrets = baseSecrets): RunRes
   const dockerLogPath = join(tempDir, "docker.log");
   const mkdirLogPath = join(tempDir, "mkdir.log");
   const chownLogPath = join(tempDir, "chown.log");
+  const systemctlLogPath = join(tempDir, "systemctl.log");
   const bashEnvPath = join(tempDir, "bash-env.sh");
   writeFileSync(bashEnvPath, [
     asBashFunction("curl", createCurlMock(metadata, secrets)),
     asBashFunction("docker", createDockerMock(toBashPath(dockerLogPath))),
     asBashFunction("mkdir", createNoopMock(toBashPath(mkdirLogPath), "mkdir")),
-    asBashFunction("chown", createNoopMock(toBashPath(chownLogPath), "chown"))
+    asBashFunction("chown", createNoopMock(toBashPath(chownLogPath), "chown")),
+    asBashFunction("systemctl", createSystemctlMock(toBashPath(systemctlLogPath)))
   ].join("\n"));
 
   const bashExecutable = process.platform === "win32"
@@ -155,10 +168,27 @@ function runRedeploy(metadata: Metadata, secrets: Secrets = baseSecrets): RunRes
     stdout: result.stdout,
     stderr: result.stderr,
     dockerLog: readFileSync(dockerLogPath, { encoding: "utf8", flag: "a+" }),
+    systemctlLog: readFileSync(systemctlLogPath, { encoding: "utf8", flag: "a+" }),
   };
 }
 
 describe("scripts/redeploy.sh auth validation", () => {
+  it("creates the container without a restart policy and starts it through systemd", () => {
+    const result = runRedeploy(baseMetadata, {
+      ...baseSecrets,
+      "actuarius-gh-token": "gh-token",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    // Container lifecycle belongs to actuarius-bot.service, which is ordered
+    // after the metadata-isolation firewall unit — a docker restart policy
+    // would race the firewall at boot.
+    expect(result.dockerLog).toMatch(/\ncreate\n/);
+    expect(result.dockerLog).not.toContain("--restart");
+    expect(result.dockerLog).not.toMatch(/\nrun\n/);
+    expect(result.systemctlLog).toContain("restart actuarius-bot.service");
+  });
+
   it("applies safe default container resource limits", () => {
     const result = runRedeploy(baseMetadata, {
       ...baseSecrets,

--- a/tests/redeployScript.test.ts
+++ b/tests/redeployScript.test.ts
@@ -15,6 +15,10 @@ type RunResult = {
   systemctlLog: string;
 };
 
+type RunOptions = {
+  unitsInstalled?: boolean;
+};
+
 const repoRoot = process.cwd();
 const scriptPath = join(repoRoot, "scripts", "redeploy.sh");
 
@@ -122,17 +126,20 @@ exit 0
 `;
 }
 
-function createSystemctlMock(logPath: string): string {
+function createSystemctlMock(logPath: string, unitsInstalled: boolean): string {
   return `#!/usr/bin/env bash
 for arg in "$@"; do
   printf '%s ' "$arg" >> ${shellSingleQuote(logPath)}
 done
 printf '\\n' >> ${shellSingleQuote(logPath)}
+if [ "\${1:-}" = cat ] && [ ${unitsInstalled ? "true" : "false"} = false ]; then
+  return 1
+fi
 exit 0
 `;
 }
 
-function runRedeploy(metadata: Metadata, secrets: Secrets = baseSecrets): RunResult {
+function runRedeploy(metadata: Metadata, secrets: Secrets = baseSecrets, options: RunOptions = {}): RunResult {
   const tempDir = mkdtempSync(join(tmpdir(), "redeploy-test-"));
   tempDirs.push(tempDir);
 
@@ -148,7 +155,7 @@ function runRedeploy(metadata: Metadata, secrets: Secrets = baseSecrets): RunRes
     asBashFunction("docker", createDockerMock(toBashPath(dockerLogPath))),
     asBashFunction("mkdir", createNoopMock(toBashPath(mkdirLogPath), "mkdir")),
     asBashFunction("chown", createNoopMock(toBashPath(chownLogPath), "chown")),
-    asBashFunction("systemctl", createSystemctlMock(toBashPath(systemctlLogPath)))
+    asBashFunction("systemctl", createSystemctlMock(toBashPath(systemctlLogPath), options.unitsInstalled ?? true))
   ].join("\n"));
 
   const bashExecutable = process.platform === "win32"
@@ -187,6 +194,18 @@ describe("scripts/redeploy.sh auth validation", () => {
     expect(result.dockerLog).not.toContain("--restart");
     expect(result.dockerLog).not.toMatch(/\nrun\n/);
     expect(result.systemctlLog).toContain("restart actuarius-bot.service");
+  });
+
+  it("fails before replacing the legacy container when the systemd units are not installed", () => {
+    const result = runRedeploy(baseMetadata, {
+      ...baseSecrets,
+      "actuarius-gh-token": "gh-token",
+    }, { unitsInstalled: false });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("complete the metadata-isolation cutover and reboot");
+    expect(result.systemctlLog).toContain("cat actuarius-firewall.service actuarius-bot.service");
+    expect(result.dockerLog).toBe("");
   });
 
   it("applies safe default container resource limits", () => {

--- a/tests/startupFirewall.test.ts
+++ b/tests/startupFirewall.test.ts
@@ -90,6 +90,7 @@ type MockState = {
   chain: "up" | "down";
   chainReadyAfterProbes?: number;
   forwardJump: "up" | "down";
+  forwardRules?: string[];
   dockerUserRules?: string[];
   genARules?: string[];
   genBRules?: string[];
@@ -109,6 +110,7 @@ function runFirewall(state: MockState): RunResult & {
   const binStatePath = join(tempDir, "state.env");
   const mutationsPath = join(tempDir, "iptables-mutations.log");
   const duPath = join(tempDir, "docker-user.rules");
+  const forwardPath = join(tempDir, "forward.rules");
   const genAPath = join(tempDir, "gen-a.rules");
   const genBPath = join(tempDir, "gen-b.rules");
   const sleepsPath = join(tempDir, "sleeps.log");
@@ -117,7 +119,6 @@ function runFirewall(state: MockState): RunResult & {
   writeFileSync(binStatePath, [
     `CHAIN_STATE=${state.chain === "up" ? 1 : 0}`,
     `CHAIN_READY_AFTER_PROBES=${state.chainReadyAfterProbes ?? 0}`,
-    `FORWARD_JUMP=${state.forwardJump === "up" ? 1 : 0}`,
     `FAIL_FLUSH=${failures.flush ? 1 : 0}`,
     `FAIL_APPEND_TCP=${failures.appendTcp ? 1 : 0}`,
     `FAIL_APPEND_UDP=${failures.appendUdp ? 1 : 0}`,
@@ -133,6 +134,7 @@ function runFirewall(state: MockState): RunResult & {
     `JUMP_A_SPEC='${JUMP_A}'`,
     `JUMP_B_SPEC='${JUMP_B}'`,
     `DU_RULES_FILE=${toBashPath(duPath)}`,
+    `FORWARD_RULES_FILE=${toBashPath(forwardPath)}`,
     `GEN_A_FILE=${toBashPath(genAPath)}`,
     `GEN_B_FILE=${toBashPath(genBPath)}`,
     `MUTATIONS_FILE=${toBashPath(mutationsPath)}`,
@@ -141,6 +143,11 @@ function runFirewall(state: MockState): RunResult & {
   ].join("\n"));
   if (state.dockerUserRules?.length) {
     writeFileSync(duPath, `${state.dockerUserRules.join("\n")}\n`);
+  }
+  const forwardRules = state.forwardRules
+    ?? (state.forwardJump === "up" ? ["-j DOCKER-USER"] : []);
+  if (forwardRules.length) {
+    writeFileSync(forwardPath, `${forwardRules.join("\n")}\n`);
   }
   if (state.genARules?.length) {
     writeFileSync(genAPath, `${state.genARules.join("\n")}\n`);
@@ -210,11 +217,8 @@ function runFirewall(state: MockState): RunResult & {
     "      return 0 ;;",
     "    -S)",
     '      if [ "$chain" = "FORWARD" ]; then',
-    '        if [ "$FORWARD_JUMP" = 1 ]; then',
-    "          printf -- '-A FORWARD -j DOCKER-USER\\n'",
-    "        else",
-    "          printf -- '-P FORWARD ACCEPT\\n'",
-    "        fi",
+    '        [ -f "$FORWARD_RULES_FILE" ] && sed "s/^/-A FORWARD /" "$FORWARD_RULES_FILE"',
+    '        [ -s "$FORWARD_RULES_FILE" ] || printf -- \'-P FORWARD ACCEPT\\n\'',
     "        return 0",
     "      fi",
     '      if [ "$chain" = "DOCKER-USER" ]; then',
@@ -411,18 +415,33 @@ describe("infra/startup.sh metadata isolation engine", () => {
     });
 
     expect(result.status, result.stderr).toBe(0);
-    // First DOCKER-USER target is ACCEPT (not a generation) -> fresh-install
-    // path: both generations detached, A rebuilt, jump inserted at position
-    // 1, ahead of the broad accept. Absent rules purge silently.
+    // A remains attached while B is built. Only after B is inserted at rule
+    // 1 is the old A jump retired, so repair introduces no new exposure gap.
     expect(result.mutations).toEqual([
-      `-D ${JUMP_A}`,
-      `-F ${GEN_A}`,
+      `-F ${GEN_B}`,
       `-A ${TCP_RETURN_RULE}`,
       `-A ${UDP_RETURN_RULE}`,
       `-A ${DROP_RULE}`,
-      `-I ${JUMP_A}`,
+      `-I ${JUMP_B}`,
+      `-D ${JUMP_A}`,
+      `-F ${GEN_A}`,
     ]);
-    expect(result.dockerUser).toEqual([JUMP_A, BROAD_ACCEPT_RULE]);
+    expect(result.dockerUser).toEqual([JUMP_B, BROAD_ACCEPT_RULE]);
+  });
+
+  it("keeps a later managed jump attached when replacement population fails", () => {
+    const harmlessPrefix = "-p icmp -j ACCEPT";
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [harmlessPrefix, JUMP_A],
+      genARules: EXPECTED_CHAIN,
+      failures: { appendDrop: true },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("could not build");
+    expect(result.dockerUser).toEqual([harmlessPrefix, JUMP_A]);
   });
 
   it("tolerates a broad metadata ACCEPT shadowed below the jump", () => {
@@ -611,6 +630,20 @@ describe("infra/startup.sh metadata isolation engine", () => {
     expect(result.stderr).toContain("not ready in time");
   });
 
+  it.each([
+    ["conditional", ["-p tcp -j DOCKER-USER"]],
+    ["shadowed", ["-j ACCEPT", "-j DOCKER-USER"]],
+  ])("fails closed when the FORWARD jump is %s", (_label, forwardRules) => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      forwardRules,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("not ready in time");
+  });
+
   it("retries until the chains appear instead of giving up immediately", () => {
     const result = runFirewall({
       chain: "up",
@@ -644,13 +677,13 @@ describe("boot-path enforcement wiring", () => {
     expect(text).toContain("LC_ALL=C iptables -w -nL");
     expect(text).toContain('iptables -w -C "$gen" $spec');
     expect(text).toContain('iptables -w -C DOCKER-USER $spec');
-    // -S appears ONLY for the FORWARD readiness probe and the unconditional
-    // first-jump check (a conditionless jump serializes identically on every
-    // backend, so exact equality is safe there and only there).
-    const sUses = text.match(/iptables -S [^\n]*/gu) ?? [];
-    expect(sUses).toHaveLength(2);
-    expect(sUses[0]).toContain("-S DOCKER-USER");
-    expect(sUses[1]).toContain("-S FORWARD");
+    // -S appears only for exact first-jump checks and for round-tripping a
+    // canonical managed-jump rule during deletion.
+    const sUses = text.split(/\r?\n/u)
+      .filter((line) => !line.trimStart().startsWith("#") && line.includes("iptables -S "));
+    expect(sUses).toHaveLength(3);
+    expect(sUses.filter((line) => line.includes("-S FORWARD"))).toHaveLength(1);
+    expect(sUses.filter((line) => line.includes("-S DOCKER-USER"))).toHaveLength(2);
     expect(text).toContain("jump_is_unconditional_first");
   });
 
@@ -674,7 +707,11 @@ describe("boot-path enforcement wiring", () => {
     expect(text).not.toContain("ExecStart=/usr/bin/bash");
     expect(text).toContain("Requires=docker.service actuarius-firewall.service");
     expect(text).toContain("After=docker.service actuarius-firewall.service");
+    expect(text).toContain('ExecStartPre=/bin/bash ${BOOTSTRAP}');
     expect(text).toContain("ExecStart=/usr/bin/docker start -a actuarius");
+    expect(text.indexOf("ExecStart=/usr/bin/docker start -a actuarius")).toBeGreaterThan(
+      text.indexOf('ExecStartPre=/bin/bash ${BOOTSTRAP}')
+    );
     expect(text).toContain("Restart=always");
     expect(text).toContain("systemctl enable actuarius-firewall.service actuarius-bot.service");
     expect(text).toContain("systemctl daemon-reload");

--- a/tests/startupFirewall.test.ts
+++ b/tests/startupFirewall.test.ts
@@ -702,6 +702,7 @@ describe("boot-path enforcement wiring", () => {
     const text = scriptText();
 
     expect(text).toContain("Requires=docker.service");
+    expect(text.match(/PartOf=docker\.service/gu)).toHaveLength(2);
     expect(text).toContain("Before=actuarius-bot.service");
     expect(text).toContain('ExecStart=/bin/bash ${BOOTSTRAP}');
     expect(text).not.toContain("ExecStart=/usr/bin/bash");

--- a/tests/startupFirewall.test.ts
+++ b/tests/startupFirewall.test.ts
@@ -1,0 +1,1043 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+// Behavioral tests for the metadata-isolation engine that infra/startup.sh
+// installs as /etc/actuarius/metadata-firewall-bootstrap.sh (security review
+// finding C-1). The engine body is extracted verbatim from the heredoc and
+// executed under bash with iptables/systemctl/sleep replaced by stateful
+// mocks via BASH_ENV, reproducing production invocation semantics
+// (`set -euo pipefail`, `harden_metadata_access || exit 1`).
+//
+// The mock emulates iptables behaviorally: -C membership, -nL listings with
+// row numbers and a target column, positional -I/-R, and multi-copy -D. The
+// engine under test deliberately avoids -S text comparison, so the mock
+// never has to fake serialization.
+
+const repoRoot = process.cwd();
+const scriptPath = join(repoRoot, "infra", "startup.sh");
+
+const METADATA_IP = "169.254.169.254";
+const GEN_A = "ACTUARIUS-META-A";
+const GEN_B = "ACTUARIUS-META-B";
+const TCP_RETURN_RULE = `-p tcp -d ${METADATA_IP}/32 --dport 53 -j RETURN`;
+const UDP_RETURN_RULE = `-p udp -d ${METADATA_IP}/32 --dport 53 -j RETURN`;
+const DROP_RULE = `-d ${METADATA_IP}/32 -j DROP`;
+const EXPECTED_CHAIN = [TCP_RETURN_RULE, UDP_RETURN_RULE, DROP_RULE];
+const JUMP_A = `-j ${GEN_A}`;
+const JUMP_B = `-j ${GEN_B}`;
+const LEGACY_DROP = `-d ${METADATA_IP}/32 -j DROP`;
+const LEGACY_UDP_ACCEPT = `-p udp -d ${METADATA_IP}/32 --dport 53 -j ACCEPT`;
+const LEGACY_TCP_ACCEPT = `-p tcp -d ${METADATA_IP}/32 --dport 53 -j ACCEPT`;
+const BROAD_ACCEPT_RULE = `-d ${METADATA_IP}/32 -j ACCEPT`;
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function toBashPath(path: string): string {
+  if (process.platform !== "win32") return path;
+  const normalized = path.replaceAll("\\", "/");
+  return normalized.replace(/^([A-Za-z]):/u, (_match, drive: string) => `/${drive.toLowerCase()}`);
+}
+
+function extractEngine(): string {
+  const lines = readFileSync(scriptPath, { encoding: "utf8" }).split(/\r?\n/u);
+  const start = lines.findIndex((line) => line.includes("<<'METADATA_FIREWALL_EOF'"));
+  const end = lines.findIndex((line) => line.trim() === "METADATA_FIREWALL_EOF");
+  expect(start, "bootstrap heredoc start not found").toBeGreaterThanOrEqual(0);
+  expect(end, "bootstrap heredoc end not found").toBeGreaterThan(start);
+  const body = lines.slice(start + 1, end).join("\n");
+  expect(body).toContain("harden_metadata_access() {");
+  expect(body).toContain("content_ok() {");
+  // The self-invocation guard is appended by a separate heredoc; the harness
+  // provides its own invocation.
+  expect(body.endsWith("}")).toBe(true);
+  return body;
+}
+
+type RunResult = {
+  status: number | null;
+  stderr: string;
+};
+
+type FailureInjection = {
+  flush?: boolean;
+  appendTcp?: boolean;
+  appendUdp?: boolean;
+  appendDrop?: boolean;
+  jumpInsert?: boolean;
+  jumpReplace?: boolean;
+  legacyDelete?: boolean;
+  strayPurge?: boolean;
+  // Silently append an extra rule right after the DROP rule lands, forcing
+  // post-repair verification to fail.
+  corruptAfterPopulate?: boolean;
+};
+
+type MockState = {
+  chain: "up" | "down";
+  chainReadyAfterProbes?: number;
+  forwardJump: "up" | "down";
+  dockerUserRules?: string[];
+  genARules?: string[];
+  genBRules?: string[];
+  failures?: FailureInjection;
+};
+
+function runFirewall(state: MockState): RunResult & {
+  mutations: string[];
+  dockerUser: string[];
+  genA: string[];
+  genB: string[];
+  sleeps: number;
+} {
+  const tempDir = mkdtempSync(join(tmpdir(), "startup-firewall-test-"));
+  tempDirs.push(tempDir);
+
+  const binStatePath = join(tempDir, "state.env");
+  const mutationsPath = join(tempDir, "iptables-mutations.log");
+  const duPath = join(tempDir, "docker-user.rules");
+  const genAPath = join(tempDir, "gen-a.rules");
+  const genBPath = join(tempDir, "gen-b.rules");
+  const sleepsPath = join(tempDir, "sleeps.log");
+
+  const failures = state.failures ?? {};
+  writeFileSync(binStatePath, [
+    `CHAIN_STATE=${state.chain === "up" ? 1 : 0}`,
+    `CHAIN_READY_AFTER_PROBES=${state.chainReadyAfterProbes ?? 0}`,
+    `FORWARD_JUMP=${state.forwardJump === "up" ? 1 : 0}`,
+    `FAIL_FLUSH=${failures.flush ? 1 : 0}`,
+    `FAIL_APPEND_TCP=${failures.appendTcp ? 1 : 0}`,
+    `FAIL_APPEND_UDP=${failures.appendUdp ? 1 : 0}`,
+    `FAIL_APPEND_DROP=${failures.appendDrop ? 1 : 0}`,
+    `FAIL_JUMP_INSERT=${failures.jumpInsert ? 1 : 0}`,
+    `FAIL_JUMP_REPLACE=${failures.jumpReplace ? 1 : 0}`,
+    `FAIL_LEGACY_DELETE=${failures.legacyDelete ? 1 : 0}`,
+    `FAIL_STRAY_PURGE=${failures.strayPurge ? 1 : 0}`,
+    `CORRUPT_AFTER_POPULATE=${failures.corruptAfterPopulate ? 1 : 0}`,
+    `GEN_A=${GEN_A}`,
+    `GEN_B=${GEN_B}`,
+    `LEGACY_DROP_SPEC='${LEGACY_DROP}'`,
+    `JUMP_A_SPEC='${JUMP_A}'`,
+    `JUMP_B_SPEC='${JUMP_B}'`,
+    `DU_RULES_FILE=${toBashPath(duPath)}`,
+    `GEN_A_FILE=${toBashPath(genAPath)}`,
+    `GEN_B_FILE=${toBashPath(genBPath)}`,
+    `MUTATIONS_FILE=${toBashPath(mutationsPath)}`,
+    `SLEEPS_FILE=${toBashPath(sleepsPath)}`,
+    "",
+  ].join("\n"));
+  if (state.dockerUserRules?.length) {
+    writeFileSync(duPath, `${state.dockerUserRules.join("\n")}\n`);
+  }
+  if (state.genARules?.length) {
+    writeFileSync(genAPath, `${state.genARules.join("\n")}\n`);
+  }
+  if (state.genBRules?.length) {
+    writeFileSync(genBPath, `${state.genBRules.join("\n")}\n`);
+  }
+
+  const mockFunctions = [
+    `source ${toBashPath(binStatePath)} || exit 99`,
+    "probe_count=$CHAIN_READY_AFTER_PROBES",
+    "rules_file_for() {",
+    '  case "$1" in',
+    '    DOCKER-USER) printf \'%s\' "$DU_RULES_FILE" ;;',
+    '    "$GEN_A") printf \'%s\' "$GEN_A_FILE" ;;',
+    '    "$GEN_B") printf \'%s\' "$GEN_B_FILE" ;;',
+    '    *) return 2 ;;',
+    "  esac",
+    "}",
+    "systemctl() {",
+    '  if [ "$1" = "is-active" ]; then',
+    '    if [ "$CHAIN_STATE" = 1 ]; then return 0; fi',
+    "    return 1",
+    "  fi",
+    "  return 0",
+    "}",
+    // Emit an -nL-style listing: two header rows, then numbered data rows
+    // whose second column is the rule's target. This is what the engine's
+    // LC_ALL=C parsing relies on.
+    "emit_listing() {",
+    '  local f="$1" chain="$2" n=0 line tgt',
+    '  printf \'Chain %s (policy ACCEPT)\\n\' "$chain"',
+    '  printf \'target     prot opt source               destination\\n\'',
+    '  [ -f "$f" ] || return 0',
+    '  while IFS= read -r line; do',
+    '    [ -n "$line" ] || continue',
+    "    n=$((n + 1))",
+    '    # Reproduce real -nL behavior: CONDITIONAL jumps still report their',
+    '    # target chain in the target column. The engine must therefore not',
+    '    # rely on that column alone.',
+    '    case "$line" in',
+    '      "-j "*) tgt="${line#-j }" ;;',
+    '      *"-j "*) tgt="${line##*-j }" ;;',
+    '      *) tgt="UNKNOWN" ;;',
+    "    esac",
+    '    printf \'%d %s prot opt 0.0.0.0/0 0.0.0.0/0\\n\' "$n" "$tgt"',
+    '  done < "$f"',
+    "}",
+    "iptables() {",
+    '  # The script passes bare "-w" (no timeout argument); eat exactly it.',
+    '  if [ "${1:-}" = "-w" ]; then shift 1; fi',
+    '  local op="$1"',
+    '  local chain="${2:-}"',
+    '  case "$op" in',
+    "    -nL)",
+    '      if [ "$chain" = "DOCKER-USER" ]; then',
+    '        if [ "$CHAIN_STATE" = 1 ] && [ "$probe_count" -le 0 ]; then',
+    '          emit_listing "$DU_RULES_FILE" "$chain"',
+    "          return 0",
+    "        fi",
+    "        probe_count=$((probe_count - 1))",
+    "        return 2",
+    "      fi",
+    '      local f; f="$(rules_file_for "$chain")" || return 2',
+    '      [ -f "$f" ] || return 2',
+    '      emit_listing "$f" "$chain"',
+    "      return 0 ;;",
+    "    -S)",
+    '      if [ "$chain" = "FORWARD" ]; then',
+    '        if [ "$FORWARD_JUMP" = 1 ]; then',
+    "          printf -- '-A FORWARD -j DOCKER-USER\\n'",
+    "        else",
+    "          printf -- '-P FORWARD ACCEPT\\n'",
+    "        fi",
+    "        return 0",
+    "      fi",
+    '      if [ "$chain" = "DOCKER-USER" ]; then',
+    '        [ -f "$DU_RULES_FILE" ] && sed "s/^/-A DOCKER-USER /" "$DU_RULES_FILE"',
+    "        return 0",
+    "      fi",
+    '      echo "unexpected -S use: $*" >&2',
+    "      return 64 ;;",
+    "    -N)",
+    '      local f; f="$(rules_file_for "$chain")" || return 2',
+    '      [ -f "$f" ] || : > "$f"',
+    "      return 0 ;;",
+    "    -F)",
+    '      if [ "$FAIL_FLUSH" = 1 ]; then return 1; fi',
+    '      local f; f="$(rules_file_for "$chain")" || return 2',
+    '      : > "$f"',
+    '      printf \'%s\\n\' "-F $chain" >> "$MUTATIONS_FILE"',
+    "      return 0 ;;",
+    "    -A)",
+    "      shift 2",
+    '      local f; f="$(rules_file_for "$chain")" || return 2',
+    '      if [ "$FAIL_APPEND_TCP" = 1 ] && printf \'%s\' "$*" | grep -q -- "-p tcp"; then return 1; fi',
+    '      if [ "$FAIL_APPEND_UDP" = 1 ] && printf \'%s\' "$*" | grep -q -- "-p udp"; then return 1; fi',
+    '      if [ "$FAIL_APPEND_DROP" = 1 ] && printf \'%s\' "$*" | grep -q -- "-j DROP"; then return 1; fi',
+    '      printf \'%s\\n\' "$*" >> "$f"',
+    '      printf \'%s\\n\' "-A $*" >> "$MUTATIONS_FILE"',
+    '      if [ "$CORRUPT_AFTER_POPULATE" = 1 ] && printf \'%s\' "$*" | grep -q -- "-j DROP"; then',
+    '        printf \'%s\\n\' "-p sctp -j ACCEPT" >> "$f"',
+    "      fi",
+    "      return 0 ;;",
+    "    -C)",
+    "      shift 2",
+    '      grep -Fxq -- "$*" "$(rules_file_for "$chain")" 2>/dev/null',
+    "      return $? ;;",
+    "    -I)",
+    '      if [ "$chain" != "DOCKER-USER" ]; then return 64; fi',
+    "      shift 3 # -I <chain> <position>",
+    '      if [ "$FAIL_JUMP_INSERT" = 1 ]; then return 1; fi',
+    '      local f; f="$DU_RULES_FILE"',
+    '      { printf \'%s\\n\' "$*"; cat "$f" 2>/dev/null || true; } > "$f.tmp" && mv "$f.tmp" "$f"',
+    '      printf \'%s\\n\' "-I $*" >> "$MUTATIONS_FILE"',
+    "      return 0 ;;",
+    "    -R)",
+    '      if [ "$chain" != "DOCKER-USER" ]; then return 64; fi',
+    "      shift 3 # -R <chain> <position>",
+    '      if [ "$FAIL_JUMP_REPLACE" = 1 ]; then return 1; fi',
+    '      local f; f="$DU_RULES_FILE"',
+    '      { printf \'%s\\n\' "$*"; tail -n +2 "$f" 2>/dev/null || true; } > "$f.tmp" && mv "$f.tmp" "$f"',
+    '      printf \'%s\\n\' "-R $*" >> "$MUTATIONS_FILE"',
+    "      return 0 ;;",
+    "    -D)",
+    "      shift 2",
+    '      local f; f="$(rules_file_for "$chain")" || return 2',
+    '      if ! grep -Fxq -- "$*" "$f" 2>/dev/null; then return 1; fi',
+    '      if [ "$FAIL_LEGACY_DELETE" = 1 ] && [ "$*" = "$LEGACY_DROP_SPEC" ]; then return 1; fi',
+    '      if [ "$FAIL_STRAY_PURGE" = 1 ] && { [ "$*" = "$JUMP_A_SPEC" ] || [ "$*" = "$JUMP_B_SPEC" ]; }; then return 1; fi',
+    '      printf \'%s\\n\' "-D $*" >> "$MUTATIONS_FILE"',
+    '      grep -Fvx -- "$*" "$f" > "$f.tmp"; mv "$f.tmp" "$f"',
+    "      return 0 ;;",
+    "  esac",
+    '  echo "unexpected iptables call: $*" >&2',
+    "  return 64",
+    "}",
+    "sleep() {",
+    '  printf \'sleep\\n\' >> "$SLEEPS_FILE"',
+    "}",
+    "",
+  ].join("\n");
+
+  const bashEnvPath = join(tempDir, "bash-env.sh");
+  writeFileSync(bashEnvPath, mockFunctions);
+
+  const harnessPath = join(tempDir, "harness.sh");
+  writeFileSync(harnessPath, [
+    "set -euo pipefail",
+    extractEngine(),
+    "harden_metadata_access || exit 1",
+    "",
+  ].join("\n"));
+
+  const bashExecutable = process.platform === "win32"
+    ? join(process.env.ProgramFiles ?? "C:\\Program Files", "Git", "bin", "bash.exe")
+    : "bash";
+  const result = spawnSync(bashExecutable, [toBashPath(harnessPath)], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      BASH_ENV: toBashPath(bashEnvPath),
+    },
+    encoding: "utf8",
+  });
+
+  const readLines = (path: string): string[] =>
+    readFileSync(path, { encoding: "utf8", flag: "a+" })
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    mutations: readLines(mutationsPath),
+    dockerUser: readLines(duPath),
+    genA: readLines(genAPath),
+    genB: readLines(genBPath),
+    sleeps: readLines(sleepsPath).length,
+  };
+}
+
+describe("infra/startup.sh metadata isolation engine", () => {
+  it("makes zero mutations when the active generation already satisfies policy", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A],
+      genARules: EXPECTED_CHAIN,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mutations).toEqual([]);
+    expect(result.dockerUser).toEqual([JUMP_A]);
+    expect(result.genA).toEqual(EXPECTED_CHAIN);
+    expect(result.genB).toEqual([]);
+  });
+
+  it("installs generation A and the jump from scratch on a fresh host", () => {
+    const result = runFirewall({ chain: "up", forwardJump: "up" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mutations).toEqual([
+      `-F ${GEN_A}`,
+      `-A ${TCP_RETURN_RULE}`,
+      `-A ${UDP_RETURN_RULE}`,
+      `-A ${DROP_RULE}`,
+      `-I ${JUMP_A}`,
+    ]);
+    expect(result.dockerUser).toEqual([JUMP_A]);
+    expect(result.genA).toEqual(EXPECTED_CHAIN);
+  });
+
+  it("repairs into the unreferenced generation and flips atomically", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A],
+      genARules: [...EXPECTED_CHAIN, "-p sctp -j ACCEPT"],
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    // Build B fully (detached), THEN flip atomically (-R replaces the old
+    // jump, leaving nothing to purge), THEN retire A. The live chain is
+    // never flushed while referenced.
+    expect(result.mutations).toEqual([
+      `-F ${GEN_B}`,
+      `-A ${TCP_RETURN_RULE}`,
+      `-A ${UDP_RETURN_RULE}`,
+      `-A ${DROP_RULE}`,
+      `-R ${JUMP_B}`,
+      `-F ${GEN_A}`,
+    ]);
+    expect(result.dockerUser).toEqual([JUMP_B]);
+    expect(result.genB).toEqual(EXPECTED_CHAIN);
+    expect(result.genA).toEqual([]);
+  });
+
+  it("alternates generations when drift recurs on the newly active generation", () => {
+    const second = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_B],
+      genBRules: [...EXPECTED_CHAIN, "-p sctp -j ACCEPT"],
+      genARules: [],
+    });
+    expect(second.status, second.stderr).toBe(0);
+    expect(second.mutations).toEqual([
+      `-F ${GEN_A}`,
+      `-A ${TCP_RETURN_RULE}`,
+      `-A ${UDP_RETURN_RULE}`,
+      `-A ${DROP_RULE}`,
+      `-R ${JUMP_A}`,
+      `-F ${GEN_B}`,
+    ]);
+    expect(second.dockerUser).toEqual([JUMP_A]);
+    expect(second.genA).toEqual(EXPECTED_CHAIN);
+    expect(second.genB).toEqual([]);
+  });
+
+  it("treats a broad metadata ACCEPT above the jump as drift and repairs above it", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [BROAD_ACCEPT_RULE, JUMP_A],
+      genARules: EXPECTED_CHAIN,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    // First DOCKER-USER target is ACCEPT (not a generation) -> fresh-install
+    // path: both generations detached, A rebuilt, jump inserted at position
+    // 1, ahead of the broad accept. Absent rules purge silently.
+    expect(result.mutations).toEqual([
+      `-D ${JUMP_A}`,
+      `-F ${GEN_A}`,
+      `-A ${TCP_RETURN_RULE}`,
+      `-A ${UDP_RETURN_RULE}`,
+      `-A ${DROP_RULE}`,
+      `-I ${JUMP_A}`,
+    ]);
+    expect(result.dockerUser).toEqual([JUMP_A, BROAD_ACCEPT_RULE]);
+  });
+
+  it("tolerates a broad metadata ACCEPT shadowed below the jump", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A, BROAD_ACCEPT_RULE],
+      genARules: EXPECTED_CHAIN,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mutations).toEqual([]);
+  });
+
+  it.each([
+    ["protocol-conditioned", "-p tcp -j ACTUARIUS-META-A"],
+    ["source-conditioned", `-s 10.88.0.0/16 -j ${GEN_A}`],
+    ["destination-conditioned", `-d ${METADATA_IP}/32 -j ${GEN_A}`],
+    ["interface-conditioned", `-i eth0 -j ${GEN_A}`],
+  ])("rejects a %s first rule as conditional drift and repairs above it", (_label, conditionalRule) => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [conditionalRule],
+      genARules: EXPECTED_CHAIN,
+    });
+
+    // The -nL target column reports GEN_A for conditional jumps, so only
+    // the exact unconditional-jump check can catch this.
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mutations).toEqual([
+      `-F ${GEN_B}`,
+      `-A ${TCP_RETURN_RULE}`,
+      `-A ${UDP_RETURN_RULE}`,
+      `-A ${DROP_RULE}`,
+      `-R ${JUMP_B}`,
+      `-F ${GEN_A}`,
+    ]);
+    expect(result.dockerUser).toEqual([JUMP_B]);
+    expect(result.genB).toEqual(EXPECTED_CHAIN);
+  });
+
+  it("purges surviving legacy rules because their absence is load-bearing for DNS", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A, LEGACY_DROP, LEGACY_TCP_ACCEPT, LEGACY_UDP_ACCEPT],
+      genARules: EXPECTED_CHAIN,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    // Any drift — legacy presence included — triggers a full repair into the
+    // other generation.
+    expect(result.mutations.filter((entry) => entry.startsWith("-D"))).toEqual([
+      `-D ${LEGACY_DROP}`,
+      `-D ${LEGACY_UDP_ACCEPT}`,
+      `-D ${LEGACY_TCP_ACCEPT}`,
+    ]);
+    expect(result.dockerUser).toEqual([JUMP_B]);
+  });
+
+  it("fails closed when a legacy DROP cannot be removed", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A, LEGACY_DROP],
+      genARules: EXPECTED_CHAIN,
+      failures: { legacyDelete: true },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("legacy");
+  });
+
+  it("fails closed when a stray jump to the other generation cannot be detached", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A, JUMP_B],
+      genARules: EXPECTED_CHAIN,
+      failures: { strayPurge: true },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("cannot detach");
+  });
+
+  it("retires a stray jump below the active one during repair", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A, JUMP_B],
+      genARules: EXPECTED_CHAIN,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    // Pre-flip detach purges the stray B jump (both copies in the mock),
+    // B is rebuilt detached, the jump flips to B, A is retired.
+    expect(result.mutations).toEqual([
+      `-D ${JUMP_B}`,
+      `-F ${GEN_B}`,
+      `-A ${TCP_RETURN_RULE}`,
+      `-A ${UDP_RETURN_RULE}`,
+      `-A ${DROP_RULE}`,
+      `-R ${JUMP_B}`,
+      `-F ${GEN_A}`,
+    ]);
+    expect(result.dockerUser).toEqual([JUMP_B]);
+  });
+
+  it("fails closed when building the replacement generation fails", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A],
+      genARules: [...EXPECTED_CHAIN, "-p sctp -j ACCEPT"],
+      failures: { appendDrop: true },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("could not build");
+    // The live jump was untouched.
+    expect(result.dockerUser).toEqual([JUMP_A]);
+  });
+
+  it("fails closed when flushing the replacement generation fails", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      failures: { flush: true },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("could not build");
+  });
+
+  it("fails closed when the atomic jump switch fails", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A],
+      genARules: [...EXPECTED_CHAIN, "-p sctp -j ACCEPT"],
+      failures: { jumpReplace: true },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("could not switch");
+    expect(result.dockerUser).toEqual([JUMP_A]);
+  });
+
+  it("fails closed when installing the first jump fails", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      failures: { jumpInsert: true },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("could not install");
+  });
+
+  it("fails closed when post-repair verification detects corruption", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      dockerUserRules: [JUMP_A],
+      genARules: [...EXPECTED_CHAIN, "-p sctp -j ACCEPT"],
+      failures: { corruptAfterPopulate: true },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("post-repair verification");
+  });
+
+  it("fails closed when docker never becomes ready", () => {
+    const result = runFirewall({ chain: "down", forwardJump: "up" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("not ready in time");
+  });
+
+  it("fails closed when DOCKER-USER is not jumped from FORWARD", () => {
+    const result = runFirewall({ chain: "up", forwardJump: "down" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("not ready in time");
+  });
+
+  it("retries until the chains appear instead of giving up immediately", () => {
+    const result = runFirewall({
+      chain: "up",
+      forwardJump: "up",
+      chainReadyAfterProbes: 5,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.sleeps).toBeGreaterThanOrEqual(5);
+    expect(result.dockerUser).toEqual([JUMP_A]);
+    expect(result.genA).toEqual(EXPECTED_CHAIN);
+  });
+});
+
+describe("boot-path enforcement wiring", () => {
+  const scriptText = (): string =>
+    readFileSync(scriptPath, { encoding: "utf8" });
+
+  it("keeps the bootstrap invocation fail-closed and ahead of the redeploy step", () => {
+    const lines = scriptText().split(/\r?\n/u);
+    const invocation = lines.findIndex((line) => line.trim() === 'bash "$BOOTSTRAP"');
+    const redeployInstall = lines.findIndex((line) => line.includes("--- Install redeploy helper script"));
+
+    expect(invocation).toBeGreaterThan(0);
+    expect(redeployInstall).toBeGreaterThan(invocation);
+    expect(scriptText()).toContain("harden_metadata_access || exit 1");
+  });
+
+  it("verifies semantics instead of serialization spelling", () => {
+    const text = scriptText();
+    expect(text).toContain("LC_ALL=C iptables -w -nL");
+    expect(text).toContain('iptables -w -C "$gen" $spec');
+    expect(text).toContain('iptables -w -C DOCKER-USER $spec');
+    // -S appears ONLY for the FORWARD readiness probe and the unconditional
+    // first-jump check (a conditionless jump serializes identically on every
+    // backend, so exact equality is safe there and only there).
+    const sUses = text.match(/iptables -S [^\n]*/gu) ?? [];
+    expect(sUses).toHaveLength(2);
+    expect(sUses[0]).toContain("-S DOCKER-USER");
+    expect(sUses[1]).toContain("-S FORWARD");
+    expect(text).toContain("jump_is_unconditional_first");
+  });
+
+  it("documents the stateless-/etc boot reality", () => {
+    const text = scriptText();
+    expect(text).toContain("STATELESS");
+    expect(text).toContain("scripts/cutover-metadata-isolation.sh");
+    // Units are (re)written unconditionally on every boot before enablement.
+    expect(text.indexOf(`cat > "$FIREWALL_UNIT"`)).toBeGreaterThan(-1);
+    expect(text.indexOf("systemctl daemon-reload")).toBeGreaterThan(
+      text.indexOf(`cat > "$BOT_UNIT"`)
+    );
+  });
+
+  it("orders systemd so the container cannot start before isolation", () => {
+    const text = scriptText();
+
+    expect(text).toContain("Requires=docker.service");
+    expect(text).toContain("Before=actuarius-bot.service");
+    expect(text).toContain('ExecStart=/bin/bash ${BOOTSTRAP}');
+    expect(text).not.toContain("ExecStart=/usr/bin/bash");
+    expect(text).toContain("Requires=docker.service actuarius-firewall.service");
+    expect(text).toContain("After=docker.service actuarius-firewall.service");
+    expect(text).toContain("ExecStart=/usr/bin/docker start -a actuarius");
+    expect(text).toContain("Restart=always");
+    expect(text).toContain("systemctl enable actuarius-firewall.service actuarius-bot.service");
+    expect(text).toContain("systemctl daemon-reload");
+  });
+});
+
+describe("first-rollout cutover tooling", () => {
+  const cutoverPath = join(repoRoot, "scripts", "cutover-metadata-isolation.sh");
+
+  const OLD_STARTUP_PAYLOAD = [
+    "#!/bin/bash",
+    "curl -sf -H 'Metadata-Flavor: Google' \"$META/env-redeploy-script\" > /var/redeploy.sh",
+    "bash /var/redeploy.sh",
+    "",
+  ].join("\n");
+  const OLD_REDEPLOY_PAYLOAD = [
+    "docker run -d --name actuarius --restart unless-stopped \\",
+    "",
+  ].join("\n");
+  // Real repo bytes: compute.tf publishes these exact files as metadata
+  // payloads, and the cutover script's embedded hashes are computed over
+  // them. A pristine fetch therefore matches by construction.
+  const NEW_STARTUP_PAYLOAD = readFileSync(join(repoRoot, "infra", "startup.sh"), { encoding: "utf8" });
+  const NEW_REDEPLOY_PAYLOAD = readFileSync(join(repoRoot, "scripts", "redeploy.sh"), { encoding: "utf8" });
+
+  type MetadataMode = "ok" | "http_fail" | "missing_startup" | "missing_redeploy" | "old_startup" | "old_redeploy";
+
+  type CutoverState = {
+    daemonUp?: boolean;
+    containerExists?: boolean;
+    // Generic (non no-such-object) inspect failure instead of success.
+    containerInspectError?: boolean;
+    policy?: "unless-stopped" | "no";
+    running?: "true" | "false";
+    updateFails?: boolean;
+    stopFails?: boolean;
+    // Every inspect after the first successful update fails generically.
+    inspectFailAfterUpdate?: boolean;
+    metadataMode?: MetadataMode;
+    // Serve payloads whose bytes deviate from the reviewed release while
+    // still containing every structural marker — a known-vulnerable prior
+    // revision must fail on hash comparison alone.
+    staleMarkedPayload?: boolean;
+  };
+
+  function runCutover(state: CutoverState): RunResult & {
+    stdout: string;
+    dockerCalls: string[];
+    curlCalls: string[];
+    finalPolicy: string;
+    finalRunning: string;
+  } {
+    const tempDir = mkdtempSync(join(tmpdir(), "cutover-test-"));
+    tempDirs.push(tempDir);
+
+    const binStatePath = join(tempDir, "state.env");
+    const dockerLogPath = join(tempDir, "docker-calls.log");
+    const curlLogPath = join(tempDir, "curl-calls.log");
+    const policyPath = join(tempDir, "policy.txt");
+    const runningPath = join(tempDir, "running.txt");
+    const updateCountPath = join(tempDir, "update-count.txt");
+    const startupPayloadPath = join(tempDir, "payload-startup.txt");
+    const redeployPayloadPath = join(tempDir, "payload-redeploy.txt");
+    // Serve REAL repo file bytes: the embedded EXPECTED_*_SHA256 constants
+    // are computed over exactly these files (compute.tf publishes them via
+    // file(...)), so a pristine fetch matches by construction. Env-supplied
+    // hashes would be a security hole — the script's embedded constants are
+    // authoritative and cannot be overridden.
+    const mode = state.metadataMode ?? "ok";
+    const startupPayload =
+      state.staleMarkedPayload ? `${NEW_STARTUP_PAYLOAD}# stale revision\n`
+        : mode === "old_startup" ? OLD_STARTUP_PAYLOAD
+          : mode === "missing_startup" ? null
+            : NEW_STARTUP_PAYLOAD;
+    const redeployPayload =
+      state.staleMarkedPayload ? `${NEW_REDEPLOY_PAYLOAD}# stale revision\n`
+        : mode === "old_redeploy" ? OLD_REDEPLOY_PAYLOAD
+          : mode === "missing_redeploy" ? null
+            : NEW_REDEPLOY_PAYLOAD;
+    writeFileSync(binStatePath, [
+      `DOCKER_INFO_OK=${state.daemonUp === false ? 0 : 1}`,
+      `CONTAINER_EXISTS=${state.containerExists === false ? 0 : 1}`,
+      `CONTAINER_INSPECT_ERROR=${state.containerInspectError ? 1 : 0}`,
+      `POLICY_FILE=${toBashPath(policyPath)}`,
+      `RUNNING_FILE=${toBashPath(runningPath)}`,
+      `UPDATE_COUNT_FILE=${toBashPath(updateCountPath)}`,
+      `UPDATE_FAILS=${state.updateFails ? 1 : 0}`,
+      `STOP_FAILS=${state.stopFails ? 1 : 0}`,
+      `INSPECT_FAIL_AFTER_UPDATE=${state.inspectFailAfterUpdate ? 1 : 0}`,
+      `METADATA_HTTP_FAILS=${mode === "http_fail" ? 1 : 0}`,
+      `DOCKER_CALL_LOG=${toBashPath(dockerLogPath)}`,
+      `CURL_CALL_LOG=${toBashPath(curlLogPath)}`,
+      `STARTUP_PAYLOAD_FILE=${toBashPath(startupPayloadPath)}`,
+      `REDEPLOY_PAYLOAD_FILE=${toBashPath(redeployPayloadPath)}`,
+      `CONTAINER_NAME=actuarius`,
+      "",
+    ].join("\n"));
+    writeFileSync(policyPath, state.policy ?? "unless-stopped");
+    writeFileSync(runningPath, state.running ?? "true");
+    if (mode !== "http_fail") {
+      if (startupPayload !== null) {
+        writeFileSync(startupPayloadPath, startupPayload);
+      }
+      if (redeployPayload !== null) {
+        writeFileSync(redeployPayloadPath, redeployPayload);
+      }
+    }
+
+    const mockFunctions = [
+      `source ${toBashPath(binStatePath)} || exit 99`,
+      'log_docker() { printf \'%s\\n\' "$*" >> "$DOCKER_CALL_LOG"; }',
+      'log_curl() { printf \'%s\\n\' "$*" >> "$CURL_CALL_LOG"; }',
+      "docker() {",
+      "  log_docker \"$*\"",
+      '  case "$1" in',
+      "    info)",
+      '      if [ "$DOCKER_INFO_OK" = 1 ]; then return 0; fi',
+      '      echo "Cannot connect to the Docker daemon at unix:///var/run/docker.sock" >&2',
+      "      return 1 ;;",
+      "    update)",
+      '      if [ "$UPDATE_FAILS" = 1 ]; then return 1; fi',
+      '      printf \'no\' > "$POLICY_FILE"',
+      '      printf \'%s\' "$(( $(cat "$UPDATE_COUNT_FILE" 2>/dev/null || echo 0) + 1 ))" > "$UPDATE_COUNT_FILE"',
+      "      echo actuarius",
+      "      return 0 ;;",
+      "    stop)",
+      '      if [ "$STOP_FAILS" = 1 ]; then return 1; fi',
+      '      printf \'false\' > "$RUNNING_FILE"',
+      "      echo actuarius",
+      "      return 0 ;;",
+      "    inspect)",
+      '      local fmt="" name=""',
+      '      while [ "$#" -gt 0 ]; do',
+      '        case "$1" in',
+      '          -f) fmt="$2"; shift 2 ;;',
+      '          *) name="$1"; shift ;;',
+      "        esac",
+      "      done",
+      '      if [ "$CONTAINER_INSPECT_ERROR" = 1 ]; then echo "Error response from daemon: permission denied" >&2; return 1; fi',
+      '      if [ "$CONTAINER_EXISTS" != 1 ]; then echo "Error: No such object: ${name:-$CONTAINER_NAME}" >&2; return 1; fi',
+      '      if [ "${INSPECT_FAIL_AFTER_UPDATE:-0}" = 1 ] && [ "$(cat "$UPDATE_COUNT_FILE" 2>/dev/null || echo 0)" -ge 1 ]; then',
+      '        echo "Error response from daemon: transport is closing" >&2',
+      "        return 1",
+      "      fi",
+      '      case "$fmt" in',
+      '        *RestartPolicy*) cat "$POLICY_FILE" ;;',
+      '        *State.Running*) cat "$RUNNING_FILE" ;;',
+      '        *) echo "full-inspect" ;;',
+      "      esac",
+      "      return 0 ;;",
+      "  esac",
+      '  echo "unexpected docker call: $*" >&2',
+      "  return 64",
+      "}",
+      "curl() {",
+      "  log_curl \"$*\"",
+      '  if [ "$METADATA_HTTP_FAILS" = 1 ]; then echo "curl: (7) Failed to connect" >&2; return 7; fi',
+      "  local url=\"\" out=\"\" prev=\"\" a",
+      '  for a in "$@"; do',
+      '    if [ "$prev" = "-o" ]; then out="$a";',
+    '    elif [ "$a" = "-o" ]; then :;',
+      '    elif [ "${a#-}" != "$a" ]; then :;',
+      '    else url="$a"; fi',
+      '    prev="$a"',
+      "  done",
+      '  [ -n "$url" ] || return 22',
+      '  local src=""',
+      '  case "$url" in',
+      '    *env-startup-script) src="$STARTUP_PAYLOAD_FILE" ;;',
+      '    *env-redeploy-script) src="$REDEPLOY_PAYLOAD_FILE" ;;',
+      '    *) echo "unexpected metadata url: $url" >&2; return 22 ;;',
+      "  esac",
+      '  if [ ! -f "$src" ]; then echo "curl: (22) The requested URL returned error: 404" >&2; return 22; fi',
+      '  cat "$src" > "${out:?missing -o target}"',
+      "}",
+      "",
+    ].join("\n");
+
+    const bashEnvPath = join(tempDir, "bash-env.sh");
+    writeFileSync(bashEnvPath, mockFunctions);
+
+    const bashExecutable = process.platform === "win32"
+      ? join(process.env.ProgramFiles ?? "C:\\Program Files", "Git", "bin", "bash.exe")
+      : "bash";
+    const result = spawnSync(bashExecutable, [toBashPath(cutoverPath)], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        BASH_ENV: toBashPath(bashEnvPath),
+      },
+      encoding: "utf8",
+    });
+
+    const readLines = (path: string): string[] =>
+      readFileSync(path, { encoding: "utf8", flag: "a+" })
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .map((line) => line.trimEnd());
+
+    return {
+      status: result.status,
+      stderr: result.stderr,
+      stdout: result.stdout,
+      dockerCalls: readLines(dockerLogPath),
+      curlCalls: readLines(curlLogPath).map((entry) =>
+        entry.includes("env-startup-script") ? "fetch env-startup-script"
+          : entry.includes("env-redeploy-script") ? "fetch env-redeploy-script"
+            : entry
+      ),
+      finalPolicy: readFileSync(policyPath, { encoding: "utf8", flag: "a+" }).trim(),
+      finalRunning: readFileSync(runningPath, { encoding: "utf8", flag: "a+" }).trim(),
+    };
+  }
+
+  it("migrates a legacy container end-to-end and only then prints the reboot instruction", () => {
+    const result = runCutover({ policy: "unless-stopped", running: "true" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.dockerCalls).toEqual([
+      "info",
+      "inspect actuarius",
+      "inspect -f {{.HostConfig.RestartPolicy.Name}} actuarius",
+      "inspect -f {{.State.Running}} actuarius",
+      "update --restart=no actuarius",
+      "inspect -f {{.HostConfig.RestartPolicy.Name}} actuarius",
+      "stop actuarius",
+      "inspect -f {{.State.Running}} actuarius",
+    ]);
+    expect(result.curlCalls).toEqual(["fetch env-startup-script", "fetch env-redeploy-script"]);
+    expect(result.finalPolicy).toBe("no");
+    expect(result.finalRunning).toBe("false");
+    expect(result.stdout).toContain("safe to reboot");
+  });
+
+  it("reports verified-safe for an absent container but only after health and metadata checks", () => {
+    const result = runCutover({ containerExists: false, policy: "no", running: "false" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("no 'actuarius' container exists");
+    expect(result.dockerCalls).toEqual(["info", "inspect actuarius"]);
+    expect(result.curlCalls).toEqual(["fetch env-startup-script", "fetch env-redeploy-script"]);
+  });
+
+  it("exits early as already-migrated without touching docker mutations", () => {
+    const result = runCutover({ policy: "no", running: "false" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("Already migrated");
+    expect(result.dockerCalls.join("\n")).not.toContain("update");
+    expect(result.dockerCalls.join("\n")).not.toContain("stop");
+  });
+
+  it("fails closed when the docker daemon is unreachable, before any metadata fetch", () => {
+    const result = runCutover({ daemonUp: false });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("daemon unavailable");
+    expect(result.dockerCalls).toEqual(["info"]);
+    expect(result.curlCalls).toEqual([]);
+  });
+
+  it("fails closed on generic docker inspect errors instead of claiming no container", () => {
+    const result = runCutover({ containerInspectError: true });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("docker inspect failed unexpectedly");
+    expect(result.dockerCalls.join("\n")).not.toContain("update");
+  });
+
+  const metadataFailureModes: MetadataMode[] = [
+    "http_fail",
+    "missing_startup",
+    "missing_redeploy",
+    "old_startup",
+    "old_redeploy",
+  ];
+
+  it.each(metadataFailureModes)("fails closed on %s metadata before any docker mutation", (mode) => {
+    const result = runCutover({ policy: "unless-stopped", running: "true", metadataMode: mode });
+
+    expect(result.status, result.stderr).not.toBe(0);
+    expect(result.dockerCalls.join("\n")).not.toContain("update");
+    expect(result.dockerCalls.join("\n")).not.toContain("stop");
+  });
+
+  it("rejects a stale payload that still carries every structural marker (hash binding)", () => {
+    const result = runCutover({
+      policy: "unless-stopped",
+      running: "true",
+      staleMarkedPayload: true,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("hash mismatch");
+    expect(result.dockerCalls.join("\n")).not.toContain("update");
+  });
+
+  it("resumes an interrupted migration without repeating the policy update", () => {
+    // Run 1: update lands, stop fails -> intermediate state.
+    const run1 = runCutover({ policy: "unless-stopped", running: "true", stopFails: true });
+    expect(run1.status).not.toBe(0);
+    expect(run1.stderr).toContain("still running after stop");
+    expect(run1.finalPolicy).toBe("no");
+
+    // Run 2: resumes from policy=no + running=true; no second update.
+    const run2 = runCutover({ policy: "no", running: "true" });
+    expect(run2.status, run2.stderr).toBe(0);
+    expect(run2.dockerCalls.join("\n")).not.toContain("update");
+    expect(run2.finalRunning).toBe("false");
+    expect(run2.stdout).toContain("safe to reboot");
+  });
+
+  it("binds its expected hashes to the exact reviewed startup.sh and redeploy.sh bytes", () => {
+    const text = readFileSync(cutoverPath, { encoding: "utf8" });
+
+    const embeddedStartup = text.match(/EXPECTED_STARTUP_SHA256="([0-9a-f]{64})"/u)?.[1];
+    const embeddedRedeploy = text.match(/EXPECTED_REDEPLOY_SHA256="([0-9a-f]{64})"/u)?.[1];
+    expect(embeddedStartup, "startup hash constant missing").toBeDefined();
+    expect(embeddedRedeploy, "redeploy hash constant missing").toBeDefined();
+
+    // The metadata payloads are byte-for-byte copies of these repo files
+    // (compute.tf: file(...)), so the embedded digests must track them.
+    // This test fails whenever either file changes without regenerating the
+    // constants in the same change.
+    expect(embeddedStartup).toBe(sha256(readFileSync(join(repoRoot, "infra", "startup.sh"), { encoding: "utf8" })));
+    expect(embeddedRedeploy).toBe(sha256(readFileSync(join(repoRoot, "scripts", "redeploy.sh"), { encoding: "utf8" })));
+  });
+
+  it("fails closed when docker update fails, without stopping anything", () => {
+    const result = runCutover({
+      policy: "unless-stopped",
+      running: "true",
+      updateFails: true,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("docker update failed");
+    expect(result.dockerCalls.join("\n")).not.toContain("stop");
+    expect(result.finalRunning).toBe("true");
+  });
+
+  it("fails closed when stop fails or verification cannot confirm the stopped state", () => {
+    const result = runCutover({
+      policy: "unless-stopped",
+      running: "true",
+      stopFails: true,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("still running after stop");
+    expect(result.finalRunning).toBe("true");
+  });
+
+  it("fails closed when post-update inspection becomes unavailable", () => {
+    const result = runCutover({
+      policy: "unless-stopped",
+      running: "true",
+      inspectFailAfterUpdate: true,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("restart policy did not take effect");
+    expect(result.stdout).not.toContain("safe to reboot");
+  });
+});


### PR DESCRIPTION
## Summary

- install a fail-closed `DOCKER-USER` metadata-isolation policy before the Actuarius container starts
- preserve GCE DNS access on TCP/UDP 53 while dropping all other container traffic to `169.254.169.254`
- use alternating A/B chains so drift repair never flushes or detaches the live policy before its replacement is installed
- require an unconditional first `FORWARD -> DOCKER-USER` jump and revalidate the firewall before every bot start
- move container lifecycle ownership from Docker restart policies to ordered systemd units, including Docker restart propagation
- add a hash-bound, resumable first-rollout cutover script and document it as a mandatory pre-apply upgrade gate
- add behavioral coverage for fresh install, drift repair, conditional/shadowed jumps, failure injection, lifecycle migration, and COS executable paths

Related to #131.

## Validation

- `npm run check`
- Bash syntax checks for all three shell scripts
- `npm test -- tests/startupFirewall.test.ts tests/redeployScript.test.ts` — 61 tests passed
- disposable private-only COS canary: DNS resolved, metadata HTTP blocked, 12/12 probes stayed blocked during live drift repair, and reboot ordering passed
- initial production cutover: firewall active before bot unit, metadata HTTP blocked, DNS functional, MemPalace health HTTP 200, Discord connected, container healthy with zero restarts

## Review follow-up

Commit `ddaf100` addresses the first four review findings:

- preserves a managed generation found anywhere in `DOCKER-USER` until a replacement is live
- rejects conditional or shadowed `FORWARD` jumps
- runs the bootstrap through `ExecStartPre` on every container start
- adds the mandatory cutover to `docs/deploy.md` and `README.md`

Commit `96decff` addresses the next three review findings:

- stages the two reviewed metadata payloads without stopping the VM, then requires cutover, reboot, and verification before any full Terraform apply
- prevents `redeploy.sh` from replacing the legacy container before startup has installed the systemd units
- propagates Docker restarts to both firewall and bot units so isolation is rebuilt before the bot returns

## Deployment notes

Production is currently healthy on the initial cutover release (`83d8cfe62d74a140e1a936ad942370a3834bba0d3a6185479433bdba19b92122`) with offline boot/data rollback snapshots retained. The first protected production boot failed closed because COS exposes Bash at `/bin/bash`, not `/usr/bin/bash`; the bot remained stopped. The corrected unit path was deployed and a second full stop/start passed end to end.

The stricter review-follow-up release in this PR has startup SHA-256 `ec74a0c4c7e01ea94f37dbd73552bab8751018e7d21cae30cfc1109649fe2a80` and redeploy SHA-256 `ff039d7aaba92e3e5a05241f465be0995950890d72eab7a1843ddbfceeda85cb`; it is tested and pushed but has not been applied to production.
