### PR TITLE
Upgrade MemPalace runtime to v0.1.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,13 +39,13 @@ WORKDIR /app
 # No auth required — public release assets are unauthenticated. Keep the
 # checksums in sync with the release assets when upgrading this version.
 RUN curl -fsSL \
-      https://github.com/DigitumDei/mempalace-rs/releases/download/v0.1.0/mempalace-mcp-linux-x86_64 \
+      https://github.com/DigitumDei/mempalace-rs/releases/download/v0.1.28-nightly.a0cea4c34080fcb9b58acca11accbc18972b2705/mempalace-mcp-linux-x86_64 \
       -o /usr/local/bin/mempalace-mcp \
     && curl -fsSL \
-      https://github.com/DigitumDei/mempalace-rs/releases/download/v0.1.0/mempalace-cli-linux-x86_64 \
+      https://github.com/DigitumDei/mempalace-rs/releases/download/v0.1.28-nightly.a0cea4c34080fcb9b58acca11accbc18972b2705/mempalace-cli-linux-x86_64 \
       -o /usr/local/bin/mempalace-cli \
-    && echo "908c49585c848a1713b48a7e4de873479d96b7b4e090f7932b80bc994b42511b  /usr/local/bin/mempalace-mcp" | sha256sum -c - \
-    && echo "4e71b1d14839c16665295e81927ca161f9be97a702eeae16bb217dda31941a9d  /usr/local/bin/mempalace-cli" | sha256sum -c - \
+    && echo "35639a412e9a93e0e66704795335a95f5f22b63efc3f8e1caab98497e8f02858  /usr/local/bin/mempalace-mcp" | sha256sum -c - \
+    && echo "4c1dd233eb2e1ca9c1f73d6c6d7a58d16356c7d37cd00c9892b5eef146ed3dfd  /usr/local/bin/mempalace-cli" | sha256sum -c - \
     && chmod 0755 /usr/local/bin/mempalace-mcp /usr/local/bin/mempalace-cli
 
 ENV NODE_ENV=production

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -186,6 +186,41 @@ Optional variables map directly to the redeploy metadata keys and can stay blank
 
 After `terraform apply`, reboot or re-fetch `/var/redeploy.sh` from metadata so the new metadata keys reach the container.
 
+### MemPalace binary upgrades and rollback
+
+Treat a MemPalace binary upgrade as a data migration. Coordination schema
+migrations are lazy: the new schema may not be written until the first
+coordination request. Once that happens, rolling back only the container image
+is unsafe because an older binary may not be able to write to the migrated
+SQLite tables.
+
+Before deploying an image with a newer MemPalace version:
+
+1. Record the currently deployed Actuarius image SHA.
+2. Stop `actuarius-bot.service` so the local and remote palaces have no writers.
+3. Run `sync`, then snapshot the persistent data disk. The snapshot is the
+   rollback boundary and must contain each palace's `storage.sqlite3` and
+   `lancedb/` directory from the same point in time.
+4. Start the bot again if the new image is not being deployed immediately.
+
+After deploying, verify the loopback federation server through the IAP tunnel:
+
+```bash
+curl -H "Authorization: Bearer <TOKEN>" http://127.0.0.1:8765/v1/info
+```
+
+Confirm the expected `server_version` and capabilities. For releases that add
+federated coordination, the capability list must contain `coordination`; an
+unknown `mempalace_task_get` should return `found: false`, not a capability
+error.
+
+Rollback is a paired operation: deploy the recorded old image **and** restore
+the matching pre-upgrade data-disk snapshot. Never run the old binary against a
+palace after the new binary has opened its coordination store. Existing token
+files without a `scopes` field remain unrestricted; if scopes are added, note
+that an empty array deliberately grants nothing and unknown or misspelled token
+fields fail closed.
+
 ## Adding a new env var
 
 **Non-secret config** — three places:


### PR DESCRIPTION
## Summary

- upgrade the pinned MemPalace MCP and CLI binaries from stable `v0.1.0` to the immutable `v0.1.28` candidate built from commit `a0cea4c`
- pin both Linux assets to their published SHA-256 digests
- document the paired image-and-data rollback boundary required by the lazy, one-way coordination schema migration
- document post-deploy verification for the `coordination` federation capability

## Release verification

- release tag: `v0.1.28-nightly.a0cea4c34080fcb9b58acca11accbc18972b2705`
- `SHA256SUMS.sig` verified successfully with `release/public-key.pem` from the exact release commit
- published and signed checksums:
  - `mempalace-mcp-linux-x86_64`: `35639a412e9a93e0e66704795335a95f5f22b63efc3f8e1caab98497e8f02858`
  - `mempalace-cli-linux-x86_64`: `4c1dd233eb2e1ca9c1f73d6c6d7a58d16356c7d37cd00c9892b5eef146ed3dfd`
- Debian Trixie satisfies the release's glibc 2.38+ requirement

## Validation

- `npm run check`
- `npm test -- tests/memPalaceRemoteService.test.ts tests/memPalaceRemoteStartup.test.ts tests/memPalaceClient.test.ts` — 23 tests passed
- `git diff --check`

The local Docker daemon is unavailable on this host (`127.0.0.1:2375` refused the connection), so the PR's Linux Docker build is the end-to-end validation of asset download and in-image checksum verification.

## Deployment safety

Before production redeploy, stop the bot and snapshot the persistent data disk so both `storage.sqlite3` and `lancedb/` are captured together. Rollback must restore that snapshot together with the prior image; rolling back only the binary after the new coordination store has been opened is unsafe.
